### PR TITLE
some resourcification of gmond stanzas

### DIFF
--- a/manifests/gmond/module.pp
+++ b/manifests/gmond/module.pp
@@ -1,0 +1,29 @@
+# == Define: ganglia::gmond::module
+#
+# configures a module stanza for gmond
+#
+# === Authors
+#
+# Jeremy Kitchen <kitchen@kitchen.io>
+#
+# === Copyright
+#
+# Copyright (C) 2013 3DNA Corp
+#
+#
+# name, language, enabled, path and params
+define ganglia::gmond::module (
+  $module_name = $name,
+  $path = "${ganglia::params::module_path}/${module_name}.so",
+  $enabled = undef,
+  $language = undef,
+  $params = undef,
+  $param = undef,
+) {
+  include ::ganglia::params
+  
+  file { "${::ganglia::params::gmond_conf_d}/module_${name}.conf":
+    content => template('ganglia/gmond/module.conf.erb'),
+    mode    => '0644',
+  }
+}

--- a/manifests/gmond/tcp_accept_channel.pp
+++ b/manifests/gmond/tcp_accept_channel.pp
@@ -1,0 +1,26 @@
+# == Define: ganglia::gmond::tcp_accept_channel
+#
+# configures a tcp_accept_channel stanza for gmond
+#
+# === Authors
+#
+# Jeremy Kitchen <kitchen@kitchen.io>
+#
+# === Copyright
+#
+# Copyright (C) 2013 3DNA Corp
+#
+#
+define ganglia::gmond::tcp_accept_channel (
+  $port,
+  $bind    = undef,
+  $family  = undef,
+  $timeout = undef,
+) {
+  include ::ganglia::params
+  
+  file { "${::ganglia::params::gmond_conf_d}/${name}.conf":
+    content => template('ganglia/gmond/tcp_accept_channel.conf.erb'),
+    mode    => '0644',
+  }
+}

--- a/manifests/gmond/tcp_accept_channel.pp
+++ b/manifests/gmond/tcp_accept_channel.pp
@@ -19,7 +19,7 @@ define ganglia::gmond::tcp_accept_channel (
 ) {
   include ::ganglia::params
   
-  file { "${::ganglia::params::gmond_conf_d}/${name}.conf":
+  file { "${::ganglia::params::gmond_conf_d}/tcp_accept_channel_${name}.conf":
     content => template('ganglia/gmond/tcp_accept_channel.conf.erb'),
     mode    => '0644',
   }

--- a/manifests/gmond/udp_recv_channel.pp
+++ b/manifests/gmond/udp_recv_channel.pp
@@ -1,0 +1,27 @@
+# == Define: ganglia::gmond::udp_recv_channel
+#
+# configures a udp_recv_channel stanza for gmond
+#
+# === Authors
+#
+# Jeremy Kitchen <kitchen@kitchen.io>
+#
+# === Copyright
+#
+# Copyright (C) 2013 3DNA Corp
+#
+#
+define ganglia::gmond::udp_recv_channel (
+  $port,
+  $mcast_join = undef,
+  $bind       = undef,
+  $mcast_if   = undef,
+  $family     = undef,
+) {
+  include ::ganglia::params
+  
+  file { "${::ganglia::params::gmond_conf_d}/${name}.conf":
+    content => template('ganglia/gmond/udp_recv_channel.conf.erb'),
+    mode    => '0644',
+  }
+}

--- a/manifests/gmond/udp_recv_channel.pp
+++ b/manifests/gmond/udp_recv_channel.pp
@@ -20,7 +20,7 @@ define ganglia::gmond::udp_recv_channel (
 ) {
   include ::ganglia::params
   
-  file { "${::ganglia::params::gmond_conf_d}/${name}.conf":
+  file { "${::ganglia::params::gmond_conf_d}/udp_recv_channel_${name}.conf":
     content => template('ganglia/gmond/udp_recv_channel.conf.erb'),
     mode    => '0644',
   }

--- a/manifests/gmond/udp_send_channel.pp
+++ b/manifests/gmond/udp_send_channel.pp
@@ -22,7 +22,7 @@ define ganglia::gmond::udp_send_channel (
 ) {
   include ::ganglia::params
   
-  file { "${::ganglia::params::gmond_conf_d}/${name}.conf":
+  file { "${::ganglia::params::gmond_conf_d}/udp_send_channel_${name}.conf":
     content => template('ganglia/gmond/udp_send_channel.conf.erb'),
     mode    => '0644',
   }

--- a/manifests/gmond/udp_send_channel.pp
+++ b/manifests/gmond/udp_send_channel.pp
@@ -1,0 +1,29 @@
+# == Define: ganglia::gmond::udp_send_channel
+#
+# configures a udp_send_channel stanza for gmond
+#
+# === Authors
+#
+# Jeremy Kitchen <kitchen@kitchen.io>
+#
+# === Copyright
+#
+# Copyright (C) 2013 3DNA Corp
+#
+#
+define ganglia::gmond::udp_send_channel (
+  $port,
+  $mcast_join    = undef,
+  $mcast_if      = undef,
+  $host          = undef,
+  $ttl           = undef,
+  $bind          = undef,
+  $bind_hostname = undef,
+) {
+  include ::ganglia::params
+  
+  file { "${::ganglia::params::gmond_conf_d}/${name}.conf":
+    content => template('ganglia/gmond/udp_send_channel.conf.erb'),
+    mode    => '0644',
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@
 class ganglia::params {
   $gmond_package_name   = 'ganglia-gmond'
   $gmond_service_name   = 'gmond'
+  $gmond_conf_d         = '/etc/ganglia/conf.d'
 
   $gmetad_package_name  = 'ganglia-gmetad'
   $gmetad_service_name  = 'gmetad'

--- a/templates/gmond/module.erb
+++ b/templates/gmond/module.erb
@@ -1,0 +1,21 @@
+modules {
+  module {
+    name = <%= @module_name %>
+    <% if defined? @enabled -%>
+      enabled = <%= @enabled %>
+    <%  end -%>
+    <% if @language -%>
+      language = <%= @language %>
+    <% end -%>
+    <% if @params -%>
+      params = <%= @params %>
+    <% end %>
+    <% if @param -%>
+      <% @param.each do |param, value| -%>
+        param <%= param %> {
+          value = <%= value %>
+        }
+      <% end -%>
+    <% end -%>
+  }
+}

--- a/templates/gmond/tcp_accept_channel.conf.erb
+++ b/templates/gmond/tcp_accept_channel.conf.erb
@@ -1,0 +1,13 @@
+tcp_accept_channel {
+  port = <%= @port %>
+  <% if @bind -%>
+    bind = <%= @bind %>
+  <% end -%>
+  <% if @family -%>
+    family = <%= @family %>
+  <% end -%>
+  <% if @timeout -%>
+    timeout = <%= @timeout %>
+  <% end -%>
+}
+

--- a/templates/gmond/udp_recv_channel.conf.erb
+++ b/templates/gmond/udp_recv_channel.conf.erb
@@ -1,0 +1,15 @@
+udp_recv_channel {
+  port = <%= @port %>
+  <% if @mcast_join -%>
+    mcast_join = <%= @mcast_join %>
+  <% end -%>
+  <% if @bind -%>
+    bind = <%= @bind %>
+  <% end -%>
+  <% if @mcast_if -%>
+    mcast_if = <%= @mcast_if %>
+  <% end -%>
+  <% if @family -%>
+    family = <%= @family %>
+  <% end -%>
+}

--- a/templates/gmond/udp_send_channel.conf.erb
+++ b/templates/gmond/udp_send_channel.conf.erb
@@ -1,0 +1,21 @@
+udp_send_channel {
+  port = <%= @port %>
+  <% if @mcast_join -%>
+    mcast_join = <%= @mcast_join %>
+  <% end -%>
+  <% if @mcast_if -%>
+    mcast_if = <%= @mcast_if %>
+  <% end -%>
+  <% if @host -%>
+    host = <%= @host %>
+  <% end -%>
+  <% if @ttl -%>
+    ttl = <%= @ttl %>
+  <% end -%>
+  <% if @bind -%>
+    bind = <%= @bind %>
+  <% end -%>
+  <% if @bind_hostname -%>
+    bind_hostname = <%= @bind_hostname %>
+  <% end -%>
+}


### PR DESCRIPTION
This is totally untested and not really ready for merging, but it's kinda what I had in mind in #5

Also, the more I look at the config file, I really think it might be beneficial to create resources for every stanza type, and maybe even pull the default config apart to use those resources (so the main config ends up effectively being a globals/cluster/host section and an include)

Also, I would say with this you would want to have puppet managing the `/etc/ganglia/conf.d` directory fully, but that might break existing things people have, so maybe adding a second include for the puppet-managed one would be better? I'm not a huge fan of calling it conf.d anyways, since there's also gmetad's config in there, so maybe the puppet-managed dir would be `/etc/ganglia/gmond.conf.d/` or something ... shrug.

So, a quick example of why I want this:

```
class profile::ganglia::catcher {
  include ganglia::gmond
  ganglia::gmond::udp_recv_channel {
    port => 8649,
  }

  @@ganglia::gmond::udp_send_channel {
    port => 8649,
    host => $::ipaddress,
    tag => "clustername",
  }
}

class profile::something::else {
  include ganglia::gmond
  Ganglia::Gmond::Udp_send_channel <<| tag == clustername |>>
}
```

And bam, instant clustering using exported resources as the configuration method. Use that with, say, hiera to set the cluster name and you get even more flexibility.

Also, setting up defines for metrics modules and collection groups it makes things even more flexible (think nagios_service, etc)

Again, this is just a demo and probably isn't ready for merging. If you want me to proceed, I will, though!