### PR TITLE
change gmond erb templates to gracefully handle nil variables

### DIFF
--- a/spec/system/gmond_spec.rb
+++ b/spec/system/gmond_spec.rb
@@ -44,4 +44,15 @@ describe 'ganglia::gmond class' do
   describe service(daemon_name) do
     it { should be_running }
   end
+
+  # default udp_recv_channel
+  describe port(8649) do
+    it { should be_listening.with('udp') }
+  end
+
+  # default tcp_accept_channel
+  describe port(8659) do
+    it { should be_listening.with('tcp') }
+  end
+
 end

--- a/templates/gmond.conf.debian.erb
+++ b/templates/gmond.conf.debian.erb
@@ -31,6 +31,7 @@ host {
 
 /* Feel free to specify as many udp_send_channels as you like.  Gmond 
    used to only support having a single channel */ 
+<% unless @udp_send_channel.nil? -%>
 <% @udp_send_channel.each do |channel| -%>
 udp_send_channel { 
   <%- if channel['mcast_join'] then -%>
@@ -48,7 +49,9 @@ udp_send_channel {
 } 
 
 <% end -%>
+<% end -%>
 /* You can specify as many udp_recv_channels as you like as well. */ 
+<% unless @udp_recv_channel.nil? -%>
 <% @udp_recv_channel.each do |channel| -%>
 udp_recv_channel { 
   <%- if channel['mcast_join'] then -%>
@@ -63,8 +66,10 @@ udp_recv_channel {
 } 
 
 <% end -%>
+<% end -%>
 /* You can specify as many tcp_accept_channels as you like to share 
    an xml description of the state of the cluster */ 
+<% unless @tcp_accept_channel.nil? -%>
 <% @tcp_accept_channel.each do |channel| -%>
 tcp_accept_channel { 
   <%- if channel['port'] then -%>
@@ -73,7 +78,7 @@ tcp_accept_channel {
 } 
 
 <% end -%>
-
+<% end -%>
 /* Each metrics module that is referenced by gmond must be specified and 
    loaded. If the module has been statically linked with gmond, it does not 
    require a load path. However all dynamically loadable modules must include 

--- a/templates/gmond.conf.el5.erb
+++ b/templates/gmond.conf.el5.erb
@@ -30,6 +30,7 @@ host {
 
 /* Feel free to specify as many udp_send_channels as you like.  Gmond 
    used to only support having a single channel */ 
+<% unless @udp_send_channel.nil? -%>
 <% @udp_send_channel.each do |channel| -%>
 udp_send_channel { 
   <%- if channel['mcast_join'] then -%>
@@ -47,7 +48,9 @@ udp_send_channel {
 } 
 
 <% end -%>
+<% end -%>
 /* You can specify as many udp_recv_channels as you like as well. */ 
+<% unless @udp_recv_channel.nil? -%>
 <% @udp_recv_channel.each do |channel| -%>
 udp_recv_channel { 
   <%- if channel['mcast_join'] then -%>
@@ -62,8 +65,10 @@ udp_recv_channel {
 } 
 
 <% end -%>
+<% end -%>
 /* You can specify as many tcp_accept_channels as you like to share 
    an xml description of the state of the cluster */ 
+<% unless @tcp_accept_channel.nil? -%>
 <% @tcp_accept_channel.each do |channel| -%>
 tcp_accept_channel { 
   <%- if channel['port'] then -%>
@@ -71,6 +76,7 @@ tcp_accept_channel {
   <%- end -%>
 } 
 
+<% end -%>
 <% end -%>
 /* The old internal 2.5.x metric array has been replaced by the following 
    collection_group directives.  What follows is the default behavior for 

--- a/templates/gmond.conf.el6.erb
+++ b/templates/gmond.conf.el6.erb
@@ -33,6 +33,7 @@ host {
 
 /* Feel free to specify as many udp_send_channels as you like.  Gmond
    used to only support having a single channel */
+<% unless @udp_send_channel.nil? -%>
 <% @udp_send_channel.each do |channel| -%>
 udp_send_channel {
   <%- if channel['mcast_join'] then -%>
@@ -50,7 +51,9 @@ udp_send_channel {
 }
 
 <% end -%>
+<% end -%>
 /* You can specify as many udp_recv_channels as you like as well. */
+<% unless @udp_recv_channel.nil? -%>
 <% @udp_recv_channel.each do |channel| -%>
 udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
@@ -65,8 +68,10 @@ udp_recv_channel {
 }
 
 <% end -%>
+<% end -%>
 /* You can specify as many tcp_accept_channels as you like to share
    an xml description of the state of the cluster */
+<% unless @tcp_accept_channel.nil? -%>
 <% @tcp_accept_channel.each do |channel| -%>
 tcp_accept_channel {
   <%- if channel['port'] then -%>
@@ -74,6 +79,7 @@ tcp_accept_channel {
   <%- end -%>
 }
 
+<% end -%>
 <% end -%>
 /* Each metrics module that is referenced by gmond must be specified and
    loaded. If the module has been statically linked with gmond, it does


### PR DESCRIPTION
These variables to ganglia::gmond may now safely be undef/nil:
- udp_send_channel
- udp_recv_channel
- tcp_accept_channel
