### PR TITLE
Removed lies from gmetad config for el6

### DIFF
--- a/templates/gmetad.conf.el6.erb
+++ b/templates/gmetad.conf.el6.erb
@@ -99,9 +99,10 @@ gridname "<%= @gridname %>"
 # setuid off
 #
 #-------------------------------------------------------------------------------
-# User gmetad will setuid to (defaults to "<%= @gmetad_user %>")
-# default: "<%= @gmetad_user %>"
-# setuid_username "<%= @gmetad_user %>"
+# User gmetad will setuid to (defaults to "nobody")
+# default: "nobody"
+setuid_username "<%= @gmetad_user %>"
+
 #
 #-------------------------------------------------------------------------------
 # The port gmetad will answer requests for XML


### PR DESCRIPTION
By default EL6 ganglia runs as nobody and not ganglia.
This fixes the issue by changing the user that ganglia is
run as to correct one according to the rest of the manifest.
