### PR TITLE
Add possibility to set ganglia->globals->{deaf, host_dmax, send_metadata_interval} as well as use udp_send_channel->bind_hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Usage
 ### `ganglia::gmond`
 
 This class manages the configurtion of the Ganglia `gmond` daemon.
+Following options/settings are only taken into account for RHEL6/CentOS6 as of now: 
+- gmond globals: globals_deaf, globals_host_dmax and globals_send_metadata_interval
+- udp_send_channel setting: bind_hostname
+For other OSes, we have the following behavior:
+- gmond globals take the default values provided below
+- udp_send_channel->bind_hostname is not taken into account
 
 ```puppet
     # unicast
@@ -49,6 +55,7 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
     $udp_send_channel = [
       { port => 8649, host => 'test1.example.org', ttl => 2 },
       { port => 8649, host => 'test2.example.org', ttl => 2 },
+	  { bind_hostname => "yes", host => 'test3.example.org', ttl => 1 },
     ]
     $tcp_accept_channel = [
       { port => 8649 },
@@ -66,6 +73,9 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
     ]
 
     class{ 'ganglia::gmond':
+	  globals_deaf => 'yes',
+	  globals_host_dmax => '691200',	  
+      globals_send_metadata_interval => '60'	
       cluster_name       => 'example grid',
       cluster_owner      => 'ACME, Inc.',
       cluster_latlong    => 'N32.2332147 W110.9481163',
@@ -77,6 +87,18 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
     }
 ```
 
+ * `globals_deaf`
+ 
+	`String` defaults to: `no`
+
+ * `globals_host_dmax`
+ 
+	`String` defaults to: `0`
+
+ * `globals_send_metadata_interval`
+ 
+	`String` defaults to: `300`	
+	
  * `cluster_name`
 
     `String` defaults to: `unspecified`

--- a/manifests/gmond.pp
+++ b/manifests/gmond.pp
@@ -90,9 +90,9 @@
 #
 
 class ganglia::gmond (
-  $ganglia_globals_deaf = 'no',
-  $ganglia_globals_host_dmax = '0',
-  $ganglia_globals_send_metadata_interval  = '300',
+  $globals_deaf = 'no',
+  $globals_host_dmax = '0',
+  $globals_send_metadata_interval  = '300',
   $cluster_name       = 'unspecified',
   $cluster_owner      = 'unspecified',
   $cluster_latlong    = 'unspecified',
@@ -106,9 +106,9 @@ class ganglia::gmond (
   ],
   $tcp_accept_channel = [ { port => 8659 } ],
 ) inherits ganglia::params {
-  validate_string($ganglia_globals_deaf)
-  validate_string($ganglia_globals_host_dmax)
-  validate_string($ganglia_globals_send_metadata_interval)
+  validate_string($globals_deaf)
+  validate_string($globals_host_dmax)
+  validate_string($globals_send_metadata_interval)
   validate_string($cluster_name)
   validate_string($cluster_owner)
   validate_string($cluster_latlong)

--- a/templates/gmond.conf.el6.erb
+++ b/templates/gmond.conf.el6.erb
@@ -7,12 +7,12 @@ globals {
   debug_level = 0
   max_udp_msg_len = 1472
   mute = no
-  deaf = <%= @ganglia_globals_deaf %>
+  deaf = <%= @globals_deaf %>
   allow_extra_data = yes
-  host_dmax = <%= @ganglia_globals_host_dmax %> /*secs */
+  host_dmax = <%= @globals_host_dmax %> /*secs */
   cleanup_threshold = 300 /*secs */
   gexec = no
-  send_metadata_interval = <%= @ganglia_globals_send_metadata_interval %> /*secs */
+  send_metadata_interval = <%= @globals_send_metadata_interval %> /*secs */
 }
 
 /*


### PR DESCRIPTION
We needed to be able to set the following settings in gmond.conf and tested the provided patches under CentOS6.5:
globals {
...
  deaf = yes
...
  host_dmax = 691200 /_secs */
...
  send_metadata_interval = 60 /_secs */
}

udp_send_channel {
...
  bind_hostname = yes
...
}
