### PR TITLE
Removes trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
 
     # multicast
     $udp_recv_channel = [
-      { mcast_join => '239.2.11.71', port => 8649, ttl => 1 } 
+      { mcast_join => '239.2.11.71', port => 8649, ttl => 1 }
     ]
     $udp_send_channel = [
-      { mcast_join => '239.2.11.71', port => 8649, bind => '239.2.11.71' } 
+      { mcast_join => '239.2.11.71', port => 8649, bind => '239.2.11.71' }
     ]
     $tcp_accept_channel = [
       { port => 8649 },
@@ -109,7 +109,7 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
 
          [ { mcast_join => '239.2.11.71', port => 8649, bind => '239.2.11.71' } ]
 
- * `tcp_accept_channel` 
+ * `tcp_accept_channel`
 
     `Array of Hash` defaults to:
 
@@ -119,25 +119,25 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
 
 ```puppet
     $clusters = [
-      { 
-        name     => 'test', 
+      {
+        name     => 'test',
         address  => ['test1.example.org', 'test2.example.org'],
       },
     ]
 
     class{ 'ganglia::gmetad':
-      clusters => $clusters,   
-      gridname => 'my grid',   
+      clusters => $clusters,
+      gridname => 'my grid',
     }
 ```
 
- * `clusters` 
+ * `clusters`
 
     `Array of Hash` defaults to:
 
         [ { 'name' => 'my cluster', 'address' => 'localhost' } ]
 
- * `gridname` 
+ * `gridname`
 
     `String` defaults to: `undef`
 
@@ -152,11 +152,11 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
     }
 ```
 
- * `ganglia_ip` 
+ * `ganglia_ip`
 
     `String` defaults to: `127.0.0.1`
 
- * `ganglia_port` 
+ * `ganglia_port`
 
     `String` defaults to: `8652`
 

--- a/templates/conf.php.el6.erb
+++ b/templates/conf.php.el6.erb
@@ -25,7 +25,7 @@ $rrds = "$gmetad_root/rrds";
 # otherwise, change it if it is installed elsewhere (like /usr/bin)
 define("RRDTOOL", "/usr/bin/rrdtool");
 
-# If rrdcached is being used, this argument must specify the 
+# If rrdcached is being used, this argument must specify the
 # socket to use.
 #
 # ganglia-web only requires, and should use, the low-privilege socket
@@ -39,7 +39,7 @@ $graphdir='./graph.d';
 #
 # If you want to grab data from a different ganglia source specify it here.
 # Although, it would be strange to alter the IP since the Round-Robin
-# databases need to be local to be read. 
+# databases need to be local to be read.
 #
 $ganglia_ip = "<%= @ganglia_ip %>";
 $ganglia_port = <%= @ganglia_port %>;
@@ -47,7 +47,7 @@ $ganglia_port = <%= @ganglia_port %>;
 #
 # The maximum number of dynamic graphs to display.  If you set this
 # to 0 (the default) all graphs will be shown.  This option is
-# helpful if you are viewing the web pages from a browser with a 
+# helpful if you are viewing the web pages from a browser with a
 # small pipe.
 #
 $max_graphs = 0;
@@ -72,7 +72,7 @@ $metriccols = 2;
 #
 $show_meta_snapshot = "yes";
 
-# 
+#
 # The default refresh frequency on pages.
 #
 $default_refresh = 300;
@@ -130,7 +130,7 @@ $load_scale = 1.0;
 $default_metric_color = "555555";
 
 #
-# Default metric 
+# Default metric
 #
 $default_metric = "load_one";
 
@@ -145,7 +145,7 @@ $strip_domainname = false;
 #
 #$optional_graphs = array('packet');
 
-# 
+#
 # Time ranges
 # Each value is the # of seconds in that range.
 #

--- a/templates/gmetad.conf.el6.erb
+++ b/templates/gmetad.conf.el6.erb
@@ -5,29 +5,29 @@
 #
 #-------------------------------------------------------------------------------
 # Setting the debug_level to 1 will keep daemon in the forground and
-# show only error messages. Setting this value higher than 1 will make 
+# show only error messages. Setting this value higher than 1 will make
 # gmetad output debugging information and stay in the foreground.
 # default: 0
 # debug_level 10
 #
 #-------------------------------------------------------------------------------
-# What to monitor. The most important section of this file. 
+# What to monitor. The most important section of this file.
 #
 # The data_source tag specifies either a cluster or a grid to
 # monitor. If we detect the source is a cluster, we will maintain a complete
-# set of RRD databases for it, which can be used to create historical 
+# set of RRD databases for it, which can be used to create historical
 # graphs of the metrics. If the source is a grid (it comes from another gmetad),
 # we will only maintain summary RRDs for it.
 #
-# Format: 
+# Format:
 # data_source "my cluster" [polling interval] address1:port addreses2:port ...
-# 
-# The keyword 'data_source' must immediately be followed by a unique
-# string which identifies the source, then an optional polling interval in 
-# seconds. The source will be polled at this interval on average. 
-# If the polling interval is omitted, 15sec is asssumed. 
 #
-# A list of machines which service the data source follows, in the 
+# The keyword 'data_source' must immediately be followed by a unique
+# string which identifies the source, then an optional polling interval in
+# seconds. The source will be polled at this interval on average.
+# If the polling interval is omitted, 15sec is asssumed.
+#
+# A list of machines which service the data source follows, in the
 # format ip:port, or name:port. If a port is not specified then 8649
 # (the default gmond port) is assumed.
 # default: There is no default value
@@ -83,7 +83,7 @@ gridname "<%= @gridname %>"
 #
 #-------------------------------------------------------------------------------
 # List of machines this gmetad will share XML with. Localhost
-# is always trusted. 
+# is always trusted.
 # default: There is no default value
 # trusted_hosts 127.0.0.1 169.229.50.165 my.gmetad.org
 #

--- a/templates/gmond.conf.debian.erb
+++ b/templates/gmond.conf.debian.erb
@@ -1,39 +1,39 @@
-/* This configuration is as close to 2.5.x default behavior as possible 
-   The values closely match ./gmond/metric.h definitions in 2.5.x */ 
-globals {                    
-  daemonize = yes              
-  setuid = yes             
-  user = ganglia              
-  debug_level = 0               
-  max_udp_msg_len = 1472        
-  mute = no             
-  deaf = no             
-  host_dmax = 0 /*secs */ 
-  cleanup_threshold = 300 /*secs */ 
-  gexec = no             
+/* This configuration is as close to 2.5.x default behavior as possible
+   The values closely match ./gmond/metric.h definitions in 2.5.x */
+globals {
+  daemonize = yes
+  setuid = yes
+  user = ganglia
+  debug_level = 0
+  max_udp_msg_len = 1472
+  mute = no
+  deaf = no
+  host_dmax = 0 /*secs */
+  cleanup_threshold = 300 /*secs */
+  gexec = no
   send_metadata_interval = 300 /*secs */
-} 
+}
 
-/* If a cluster attribute is specified, then all gmond hosts are wrapped inside 
- * of a <CLUSTER> tag.  If you do not specify a cluster tag, then all <HOSTS> will 
- * NOT be wrapped inside of a <CLUSTER> tag. */ 
-cluster { 
+/* If a cluster attribute is specified, then all gmond hosts are wrapped inside
+ * of a <CLUSTER> tag.  If you do not specify a cluster tag, then all <HOSTS> will
+ * NOT be wrapped inside of a <CLUSTER> tag. */
+cluster {
   name = "<%= @cluster_name %>"
   owner = "<%= @cluster_owner %>"
   latlong = "<%= @cluster_latlong %>"
   url = "<%= @cluster_url %>"
-} 
+}
 
-/* The host section describes attributes of the host, like the location */ 
-host { 
+/* The host section describes attributes of the host, like the location */
+host {
   location = "<%= @host_location %>"
-} 
+}
 
-/* Feel free to specify as many udp_send_channels as you like.  Gmond 
-   used to only support having a single channel */ 
+/* Feel free to specify as many udp_send_channels as you like.  Gmond
+   used to only support having a single channel */
 <% unless @udp_send_channel.nil? -%>
 <% @udp_send_channel.each do |channel| -%>
-udp_send_channel { 
+udp_send_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
   <%- end -%>
@@ -41,19 +41,19 @@ udp_send_channel {
   host       = <%= channel['host'] %>
   <%- end -%>
   <%- if channel['port'] then -%>
-  port       = <%= channel['port'] %> 
+  port       = <%= channel['port'] %>
   <%- end -%>
   <%- if channel['ttl'] then -%>
-  ttl        = <%= channel['ttl'] %> 
+  ttl        = <%= channel['ttl'] %>
   <%- end -%>
-} 
+}
 
 <% end -%>
 <% end -%>
-/* You can specify as many udp_recv_channels as you like as well. */ 
+/* You can specify as many udp_recv_channels as you like as well. */
 <% unless @udp_recv_channel.nil? -%>
 <% @udp_recv_channel.each do |channel| -%>
-udp_recv_channel { 
+udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
   <%- end -%>
@@ -61,312 +61,312 @@ udp_recv_channel {
   port       = <%= channel['port'] %>
   <%- end -%>
   <%- if channel['bind'] then -%>
-  bind       = <%= channel['bind'] %> 
+  bind       = <%= channel['bind'] %>
   <%- end -%>
   <%- if channel['family'] then -%>
-  family     = <%= channel['family'] %> 
+  family     = <%= channel['family'] %>
   <%- end -%>
-} 
+}
 
 <% end -%>
 <% end -%>
-/* You can specify as many tcp_accept_channels as you like to share 
-   an xml description of the state of the cluster */ 
+/* You can specify as many tcp_accept_channels as you like to share
+   an xml description of the state of the cluster */
 <% unless @tcp_accept_channel.nil? -%>
 <% @tcp_accept_channel.each do |channel| -%>
-tcp_accept_channel { 
+tcp_accept_channel {
   <%- if channel['port'] then -%>
   port       = <%= channel['port'] %>
   <%- end -%>
   <%- if channel['family'] then -%>
-  family     = <%= channel['family'] %> 
+  family     = <%= channel['family'] %>
   <%- end -%>
-} 
+}
 
 <% end -%>
 <% end -%>
-/* Each metrics module that is referenced by gmond must be specified and 
-   loaded. If the module has been statically linked with gmond, it does not 
-   require a load path. However all dynamically loadable modules must include 
-   a load path. */ 
-modules { 
-  module { 
-    name = "core_metrics" 
-  } 
-  module { 
-    name = "cpu_module" 
-    path = "/usr/lib/ganglia/modcpu.so" 
-  } 
-  module { 
-    name = "disk_module" 
-    path = "/usr/lib/ganglia/moddisk.so" 
-  } 
-  module { 
-    name = "load_module" 
-    path = "/usr/lib/ganglia/modload.so" 
-  } 
-  module { 
-    name = "mem_module" 
-    path = "/usr/lib/ganglia/modmem.so" 
-  } 
-  module { 
-    name = "net_module" 
-    path = "/usr/lib/ganglia/modnet.so" 
-  } 
-  module { 
-    name = "proc_module" 
-    path = "/usr/lib/ganglia/modproc.so" 
-  } 
-  module { 
-    name = "sys_module" 
-    path = "/usr/lib/ganglia/modsys.so" 
-  } 
-} 
+/* Each metrics module that is referenced by gmond must be specified and
+   loaded. If the module has been statically linked with gmond, it does not
+   require a load path. However all dynamically loadable modules must include
+   a load path. */
+modules {
+  module {
+    name = "core_metrics"
+  }
+  module {
+    name = "cpu_module"
+    path = "/usr/lib/ganglia/modcpu.so"
+  }
+  module {
+    name = "disk_module"
+    path = "/usr/lib/ganglia/moddisk.so"
+  }
+  module {
+    name = "load_module"
+    path = "/usr/lib/ganglia/modload.so"
+  }
+  module {
+    name = "mem_module"
+    path = "/usr/lib/ganglia/modmem.so"
+  }
+  module {
+    name = "net_module"
+    path = "/usr/lib/ganglia/modnet.so"
+  }
+  module {
+    name = "proc_module"
+    path = "/usr/lib/ganglia/modproc.so"
+  }
+  module {
+    name = "sys_module"
+    path = "/usr/lib/ganglia/modsys.so"
+  }
+}
 
-include ('/etc/ganglia/conf.d/*.conf') 
+include ('/etc/ganglia/conf.d/*.conf')
 
 
-/* The old internal 2.5.x metric array has been replaced by the following 
-   collection_group directives.  What follows is the default behavior for 
-   collecting and sending metrics that is as close to 2.5.x behavior as 
+/* The old internal 2.5.x metric array has been replaced by the following
+   collection_group directives.  What follows is the default behavior for
+   collecting and sending metrics that is as close to 2.5.x behavior as
    possible. */
 
-/* This collection group will cause a heartbeat (or beacon) to be sent every 
-   20 seconds.  In the heartbeat is the GMOND_STARTED data which expresses 
-   the age of the running gmond. */ 
-collection_group { 
-  collect_once = yes 
-  time_threshold = 20 
-  metric { 
-    name = "heartbeat" 
-  } 
-} 
+/* This collection group will cause a heartbeat (or beacon) to be sent every
+   20 seconds.  In the heartbeat is the GMOND_STARTED data which expresses
+   the age of the running gmond. */
+collection_group {
+  collect_once = yes
+  time_threshold = 20
+  metric {
+    name = "heartbeat"
+  }
+}
 
-/* This collection group will send general info about this host every 1200 secs. 
-   This information doesn't change between reboots and is only collected once. */ 
-collection_group { 
-  collect_once = yes 
-  time_threshold = 1200 
-  metric { 
-    name = "cpu_num" 
-    title = "CPU Count" 
-  } 
-  metric { 
-    name = "cpu_speed" 
-    title = "CPU Speed" 
-  } 
-  metric { 
-    name = "mem_total" 
-    title = "Memory Total" 
-  } 
-  /* Should this be here? Swap can be added/removed between reboots. */ 
-  metric { 
-    name = "swap_total" 
-    title = "Swap Space Total" 
-  } 
-  metric { 
-    name = "boottime" 
-    title = "Last Boot Time" 
-  } 
-  metric { 
-    name = "machine_type" 
-    title = "Machine Type" 
-  } 
-  metric { 
-    name = "os_name" 
-    title = "Operating System" 
-  } 
-  metric { 
-    name = "os_release" 
-    title = "Operating System Release" 
-  } 
-  metric { 
-    name = "location" 
-    title = "Location" 
-  } 
-} 
+/* This collection group will send general info about this host every 1200 secs.
+   This information doesn't change between reboots and is only collected once. */
+collection_group {
+  collect_once = yes
+  time_threshold = 1200
+  metric {
+    name = "cpu_num"
+    title = "CPU Count"
+  }
+  metric {
+    name = "cpu_speed"
+    title = "CPU Speed"
+  }
+  metric {
+    name = "mem_total"
+    title = "Memory Total"
+  }
+  /* Should this be here? Swap can be added/removed between reboots. */
+  metric {
+    name = "swap_total"
+    title = "Swap Space Total"
+  }
+  metric {
+    name = "boottime"
+    title = "Last Boot Time"
+  }
+  metric {
+    name = "machine_type"
+    title = "Machine Type"
+  }
+  metric {
+    name = "os_name"
+    title = "Operating System"
+  }
+  metric {
+    name = "os_release"
+    title = "Operating System Release"
+  }
+  metric {
+    name = "location"
+    title = "Location"
+  }
+}
 
 /* This collection group will send the status of gexecd for this host every 300 secs */
-/* Unlike 2.5.x the default behavior is to report gexecd OFF.  */ 
-collection_group { 
-  collect_once = yes 
-  time_threshold = 300 
-  metric { 
-    name = "gexec" 
-    title = "Gexec Status" 
-  } 
-} 
-
-/* This collection group will collect the CPU status info every 20 secs. 
-   The time threshold is set to 90 seconds.  In honesty, this time_threshold could be 
-   set significantly higher to reduce unneccessary network chatter. */ 
-collection_group { 
-  collect_every = 20 
-  time_threshold = 90 
-  /* CPU status */ 
-  metric { 
-    name = "cpu_user"  
-    value_threshold = "1.0" 
-    title = "CPU User" 
-  } 
-  metric { 
-    name = "cpu_system"   
-    value_threshold = "1.0" 
-    title = "CPU System" 
-  } 
-  metric { 
-    name = "cpu_idle"  
-    value_threshold = "5.0" 
-    title = "CPU Idle" 
-  } 
-  metric { 
-    name = "cpu_nice"  
-    value_threshold = "1.0" 
-    title = "CPU Nice" 
-  } 
-  metric { 
-    name = "cpu_aidle" 
-    value_threshold = "5.0" 
-    title = "CPU aidle" 
-  } 
-  metric { 
-    name = "cpu_wio" 
-    value_threshold = "1.0" 
-    title = "CPU wio" 
-  } 
-  /* The next two metrics are optional if you want more detail... 
-     ... since they are accounted for in cpu_system.  
-  metric { 
-    name = "cpu_intr" 
-    value_threshold = "1.0" 
-    title = "CPU intr" 
-  } 
-  metric { 
-    name = "cpu_sintr" 
-    value_threshold = "1.0" 
-    title = "CPU sintr" 
-  } 
-  */ 
-} 
-
-collection_group { 
-  collect_every = 20 
-  time_threshold = 90 
-  /* Load Averages */ 
-  metric { 
-    name = "load_one" 
-    value_threshold = "1.0" 
-    title = "One Minute Load Average" 
-  } 
-  metric { 
-    name = "load_five" 
-    value_threshold = "1.0" 
-    title = "Five Minute Load Average" 
-  } 
-  metric { 
-    name = "load_fifteen" 
-    value_threshold = "1.0" 
-    title = "Fifteen Minute Load Average" 
+/* Unlike 2.5.x the default behavior is to report gexecd OFF.  */
+collection_group {
+  collect_once = yes
+  time_threshold = 300
+  metric {
+    name = "gexec"
+    title = "Gexec Status"
   }
-} 
-
-/* This group collects the number of running and total processes */ 
-collection_group { 
-  collect_every = 80 
-  time_threshold = 950 
-  metric { 
-    name = "proc_run" 
-    value_threshold = "1.0" 
-    title = "Total Running Processes" 
-  } 
-  metric { 
-    name = "proc_total" 
-    value_threshold = "1.0" 
-    title = "Total Processes" 
-  } 
 }
 
-/* This collection group grabs the volatile memory metrics every 40 secs and 
-   sends them at least every 180 secs.  This time_threshold can be increased 
-   significantly to reduce unneeded network traffic. */ 
-collection_group { 
-  collect_every = 40 
-  time_threshold = 180 
-  metric { 
-    name = "mem_free" 
-    value_threshold = "1024.0" 
-    title = "Free Memory" 
-  } 
-  metric { 
-    name = "mem_shared" 
-    value_threshold = "1024.0" 
-    title = "Shared Memory" 
-  } 
-  metric { 
-    name = "mem_buffers" 
-    value_threshold = "1024.0" 
-    title = "Memory Buffers" 
-  } 
-  metric { 
-    name = "mem_cached" 
-    value_threshold = "1024.0" 
-    title = "Cached Memory" 
-  } 
-  metric { 
-    name = "swap_free" 
-    value_threshold = "1024.0" 
-    title = "Free Swap Space" 
-  } 
-} 
-
-collection_group { 
-  collect_every = 40 
-  time_threshold = 300 
-  metric { 
-    name = "bytes_out" 
-    value_threshold = 4096 
-    title = "Bytes Sent" 
-  } 
-  metric { 
-    name = "bytes_in" 
-    value_threshold = 4096 
-    title = "Bytes Received" 
-  } 
-  metric { 
-    name = "pkts_in" 
-    value_threshold = 256 
-    title = "Packets Received" 
-  } 
-  metric { 
-    name = "pkts_out" 
-    value_threshold = 256 
-    title = "Packets Sent" 
-  } 
+/* This collection group will collect the CPU status info every 20 secs.
+   The time threshold is set to 90 seconds.  In honesty, this time_threshold could be
+   set significantly higher to reduce unneccessary network chatter. */
+collection_group {
+  collect_every = 20
+  time_threshold = 90
+  /* CPU status */
+  metric {
+    name = "cpu_user"
+    value_threshold = "1.0"
+    title = "CPU User"
+  }
+  metric {
+    name = "cpu_system"
+    value_threshold = "1.0"
+    title = "CPU System"
+  }
+  metric {
+    name = "cpu_idle"
+    value_threshold = "5.0"
+    title = "CPU Idle"
+  }
+  metric {
+    name = "cpu_nice"
+    value_threshold = "1.0"
+    title = "CPU Nice"
+  }
+  metric {
+    name = "cpu_aidle"
+    value_threshold = "5.0"
+    title = "CPU aidle"
+  }
+  metric {
+    name = "cpu_wio"
+    value_threshold = "1.0"
+    title = "CPU wio"
+  }
+  /* The next two metrics are optional if you want more detail...
+     ... since they are accounted for in cpu_system.
+  metric {
+    name = "cpu_intr"
+    value_threshold = "1.0"
+    title = "CPU intr"
+  }
+  metric {
+    name = "cpu_sintr"
+    value_threshold = "1.0"
+    title = "CPU sintr"
+  }
+  */
 }
 
-/* Different than 2.5.x default since the old config made no sense */ 
-collection_group { 
-  collect_every = 1800 
-  time_threshold = 3600 
-  metric { 
-    name = "disk_total" 
-    value_threshold = 1.0 
-    title = "Total Disk Space" 
-  } 
+collection_group {
+  collect_every = 20
+  time_threshold = 90
+  /* Load Averages */
+  metric {
+    name = "load_one"
+    value_threshold = "1.0"
+    title = "One Minute Load Average"
+  }
+  metric {
+    name = "load_five"
+    value_threshold = "1.0"
+    title = "Five Minute Load Average"
+  }
+  metric {
+    name = "load_fifteen"
+    value_threshold = "1.0"
+    title = "Fifteen Minute Load Average"
+  }
 }
 
-collection_group { 
-  collect_every = 40 
-  time_threshold = 180 
-  metric { 
-    name = "disk_free" 
-    value_threshold = 1.0 
-    title = "Disk Space Available" 
-  } 
-  metric { 
-    name = "part_max_used" 
-    value_threshold = 1.0 
-    title = "Maximum Disk Space Used" 
-  } 
+/* This group collects the number of running and total processes */
+collection_group {
+  collect_every = 80
+  time_threshold = 950
+  metric {
+    name = "proc_run"
+    value_threshold = "1.0"
+    title = "Total Running Processes"
+  }
+  metric {
+    name = "proc_total"
+    value_threshold = "1.0"
+    title = "Total Processes"
+  }
+}
+
+/* This collection group grabs the volatile memory metrics every 40 secs and
+   sends them at least every 180 secs.  This time_threshold can be increased
+   significantly to reduce unneeded network traffic. */
+collection_group {
+  collect_every = 40
+  time_threshold = 180
+  metric {
+    name = "mem_free"
+    value_threshold = "1024.0"
+    title = "Free Memory"
+  }
+  metric {
+    name = "mem_shared"
+    value_threshold = "1024.0"
+    title = "Shared Memory"
+  }
+  metric {
+    name = "mem_buffers"
+    value_threshold = "1024.0"
+    title = "Memory Buffers"
+  }
+  metric {
+    name = "mem_cached"
+    value_threshold = "1024.0"
+    title = "Cached Memory"
+  }
+  metric {
+    name = "swap_free"
+    value_threshold = "1024.0"
+    title = "Free Swap Space"
+  }
+}
+
+collection_group {
+  collect_every = 40
+  time_threshold = 300
+  metric {
+    name = "bytes_out"
+    value_threshold = 4096
+    title = "Bytes Sent"
+  }
+  metric {
+    name = "bytes_in"
+    value_threshold = 4096
+    title = "Bytes Received"
+  }
+  metric {
+    name = "pkts_in"
+    value_threshold = 256
+    title = "Packets Received"
+  }
+  metric {
+    name = "pkts_out"
+    value_threshold = 256
+    title = "Packets Sent"
+  }
+}
+
+/* Different than 2.5.x default since the old config made no sense */
+collection_group {
+  collect_every = 1800
+  time_threshold = 3600
+  metric {
+    name = "disk_total"
+    value_threshold = 1.0
+    title = "Total Disk Space"
+  }
+}
+
+collection_group {
+  collect_every = 40
+  time_threshold = 180
+  metric {
+    name = "disk_free"
+    value_threshold = 1.0
+    title = "Disk Space Available"
+  }
+  metric {
+    name = "part_max_used"
+    value_threshold = 1.0
+    title = "Maximum Disk Space Used"
+  }
 }
 

--- a/templates/gmond.conf.el5.erb
+++ b/templates/gmond.conf.el5.erb
@@ -1,38 +1,38 @@
-/* This configuration is as close to 2.5.x default behavior as possible 
-   The values closely match ./gmond/metric.h definitions in 2.5.x */ 
-globals {                    
-  daemonize = yes              
-  setuid = yes             
-  user = ganglia              
-  debug_level = 0               
-  max_udp_msg_len = 1472        
-  mute = no             
-  deaf = no             
-  host_dmax = 86400 /*secs */ 
-  cleanup_threshold = 300 /*secs */ 
-  gexec = no             
-} 
+/* This configuration is as close to 2.5.x default behavior as possible
+   The values closely match ./gmond/metric.h definitions in 2.5.x */
+globals {
+  daemonize = yes
+  setuid = yes
+  user = ganglia
+  debug_level = 0
+  max_udp_msg_len = 1472
+  mute = no
+  deaf = no
+  host_dmax = 86400 /*secs */
+  cleanup_threshold = 300 /*secs */
+  gexec = no
+}
 
-/* If a cluster attribute is specified, then all gmond hosts are wrapped inside 
- * of a <CLUSTER> tag.  If you do not specify a cluster tag, then all <HOSTS> will 
- * NOT be wrapped inside of a <CLUSTER> tag. */ 
-cluster { 
+/* If a cluster attribute is specified, then all gmond hosts are wrapped inside
+ * of a <CLUSTER> tag.  If you do not specify a cluster tag, then all <HOSTS> will
+ * NOT be wrapped inside of a <CLUSTER> tag. */
+cluster {
   name = "<%= @cluster_name %>"
   owner = "<%= @cluster_owner %>"
   latlong = "<%= @cluster_latlong %>"
   url = "<%= @cluster_url %>"
-} 
+}
 
-/* The host section describes attributes of the host, like the location */ 
-host { 
+/* The host section describes attributes of the host, like the location */
+host {
   location = "<%= @host_location %>"
-} 
+}
 
-/* Feel free to specify as many udp_send_channels as you like.  Gmond 
-   used to only support having a single channel */ 
+/* Feel free to specify as many udp_send_channels as you like.  Gmond
+   used to only support having a single channel */
 <% unless @udp_send_channel.nil? -%>
 <% @udp_send_channel.each do |channel| -%>
-udp_send_channel { 
+udp_send_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
   <%- end -%>
@@ -40,19 +40,19 @@ udp_send_channel {
   host       = <%= channel['host'] %>
   <%- end -%>
   <%- if channel['port'] then -%>
-  port       = <%= channel['port'] %> 
+  port       = <%= channel['port'] %>
   <%- end -%>
   <%- if channel['ttl'] then -%>
-  ttl        = <%= channel['ttl'] %> 
+  ttl        = <%= channel['ttl'] %>
   <%- end -%>
-} 
+}
 
 <% end -%>
 <% end -%>
-/* You can specify as many udp_recv_channels as you like as well. */ 
+/* You can specify as many udp_recv_channels as you like as well. */
 <% unless @udp_recv_channel.nil? -%>
 <% @udp_recv_channel.each do |channel| -%>
-udp_recv_channel { 
+udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
   <%- end -%>
@@ -60,236 +60,236 @@ udp_recv_channel {
   port       = <%= channel['port'] %>
   <%- end -%>
   <%- if channel['bind'] then -%>
-  bind       = <%= channel['bind'] %> 
+  bind       = <%= channel['bind'] %>
   <%- end -%>
   <%- if channel['family'] then -%>
-  family     = <%= channel['family'] %> 
+  family     = <%= channel['family'] %>
   <%- end -%>
-} 
+}
 
 <% end -%>
 <% end -%>
-/* You can specify as many tcp_accept_channels as you like to share 
-   an xml description of the state of the cluster */ 
+/* You can specify as many tcp_accept_channels as you like to share
+   an xml description of the state of the cluster */
 <% unless @tcp_accept_channel.nil? -%>
 <% @tcp_accept_channel.each do |channel| -%>
-tcp_accept_channel { 
+tcp_accept_channel {
   <%- if channel['port'] then -%>
   port       = <%= channel['port'] %>
   <%- end -%>
   <%- if channel['family'] then -%>
-  family     = <%= channel['family'] %> 
+  family     = <%= channel['family'] %>
   <%- end -%>
-} 
+}
 
 <% end -%>
 <% end -%>
-/* The old internal 2.5.x metric array has been replaced by the following 
-   collection_group directives.  What follows is the default behavior for 
-   collecting and sending metrics that is as close to 2.5.x behavior as 
+/* The old internal 2.5.x metric array has been replaced by the following
+   collection_group directives.  What follows is the default behavior for
+   collecting and sending metrics that is as close to 2.5.x behavior as
    possible. */
 
-/* This collection group will cause a heartbeat (or beacon) to be sent every 
-   20 seconds.  In the heartbeat is the GMOND_STARTED data which expresses 
-   the age of the running gmond. */ 
-collection_group { 
-  collect_once = yes 
-  time_threshold = 20 
-  metric { 
-    name = "heartbeat" 
-  } 
-} 
+/* This collection group will cause a heartbeat (or beacon) to be sent every
+   20 seconds.  In the heartbeat is the GMOND_STARTED data which expresses
+   the age of the running gmond. */
+collection_group {
+  collect_once = yes
+  time_threshold = 20
+  metric {
+    name = "heartbeat"
+  }
+}
 
-/* This collection group will send general info about this host every 1200 secs. 
-   This information doesn't change between reboots and is only collected once. */ 
-collection_group { 
-  collect_once = yes 
-  time_threshold = 1200 
-  metric { 
-    name = "cpu_num" 
-  } 
-  metric { 
-    name = "cpu_speed" 
-  } 
-  metric { 
-    name = "mem_total" 
-  } 
-  /* Should this be here? Swap can be added/removed between reboots. */ 
-  metric { 
-    name = "swap_total" 
-  } 
-  metric { 
-    name = "boottime" 
-  } 
-  metric { 
-    name = "machine_type" 
-  } 
-  metric { 
-    name = "os_name" 
-  } 
-  metric { 
-    name = "os_release" 
-  } 
-  metric { 
-    name = "location" 
-  } 
-} 
+/* This collection group will send general info about this host every 1200 secs.
+   This information doesn't change between reboots and is only collected once. */
+collection_group {
+  collect_once = yes
+  time_threshold = 1200
+  metric {
+    name = "cpu_num"
+  }
+  metric {
+    name = "cpu_speed"
+  }
+  metric {
+    name = "mem_total"
+  }
+  /* Should this be here? Swap can be added/removed between reboots. */
+  metric {
+    name = "swap_total"
+  }
+  metric {
+    name = "boottime"
+  }
+  metric {
+    name = "machine_type"
+  }
+  metric {
+    name = "os_name"
+  }
+  metric {
+    name = "os_release"
+  }
+  metric {
+    name = "location"
+  }
+}
 
 /* This collection group will send the status of gexecd for this host every 300 secs */
-/* Unlike 2.5.x the default behavior is to report gexecd OFF.  */ 
-collection_group { 
-  collect_once = yes 
-  time_threshold = 300 
-  metric { 
-    name = "gexec" 
-  } 
-} 
-
-/* This collection group will collect the CPU status info every 20 secs. 
-   The time threshold is set to 90 seconds.  In honesty, this time_threshold could be 
-   set significantly higher to reduce unneccessary network chatter. */ 
-collection_group { 
-  collect_every = 20 
-  time_threshold = 90 
-  /* CPU status */ 
-  metric { 
-    name = "cpu_user"  
-    value_threshold = "1.0" 
-  } 
-  metric { 
-    name = "cpu_system"   
-    value_threshold = "1.0" 
-  } 
-  metric { 
-    name = "cpu_idle"  
-    value_threshold = "5.0" 
-  } 
-  metric { 
-    name = "cpu_nice"  
-    value_threshold = "1.0" 
-  } 
-  metric { 
-    name = "cpu_aidle" 
-    value_threshold = "5.0" 
-  } 
-  metric { 
-    name = "cpu_wio" 
-    value_threshold = "1.0" 
-  } 
-  /* The next two metrics are optional if you want more detail... 
-     ... since they are accounted for in cpu_system.  
-  metric { 
-    name = "cpu_intr" 
-    value_threshold = "1.0" 
-  } 
-  metric { 
-    name = "cpu_sintr" 
-    value_threshold = "1.0" 
-  } 
-  */ 
-} 
-
-collection_group { 
-  collect_every = 20 
-  time_threshold = 90 
-  /* Load Averages */ 
-  metric { 
-    name = "load_one" 
-    value_threshold = "1.0" 
-  } 
-  metric { 
-    name = "load_five" 
-    value_threshold = "1.0" 
-  } 
-  metric { 
-    name = "load_fifteen" 
-    value_threshold = "1.0" 
+/* Unlike 2.5.x the default behavior is to report gexecd OFF.  */
+collection_group {
+  collect_once = yes
+  time_threshold = 300
+  metric {
+    name = "gexec"
   }
-} 
-
-/* This group collects the number of running and total processes */ 
-collection_group { 
-  collect_every = 80 
-  time_threshold = 950 
-  metric { 
-    name = "proc_run" 
-    value_threshold = "1.0" 
-  } 
-  metric { 
-    name = "proc_total" 
-    value_threshold = "1.0" 
-  } 
 }
 
-/* This collection group grabs the volatile memory metrics every 40 secs and 
-   sends them at least every 180 secs.  This time_threshold can be increased 
-   significantly to reduce unneeded network traffic. */ 
-collection_group { 
-  collect_every = 40 
-  time_threshold = 180 
-  metric { 
-    name = "mem_free" 
-    value_threshold = "1024.0" 
-  } 
-  metric { 
-    name = "mem_shared" 
-    value_threshold = "1024.0" 
-  } 
-  metric { 
-    name = "mem_buffers" 
-    value_threshold = "1024.0" 
-  } 
-  metric { 
-    name = "mem_cached" 
-    value_threshold = "1024.0" 
-  } 
-  metric { 
-    name = "swap_free" 
-    value_threshold = "1024.0" 
-  } 
-} 
-
-collection_group { 
-  collect_every = 40 
-  time_threshold = 300 
-  metric { 
-    name = "bytes_out" 
-    value_threshold = 4096 
-  } 
-  metric { 
-    name = "bytes_in" 
-    value_threshold = 4096 
-  } 
-  metric { 
-    name = "pkts_in" 
-    value_threshold = 256 
-  } 
-  metric { 
-    name = "pkts_out" 
-    value_threshold = 256 
-  } 
+/* This collection group will collect the CPU status info every 20 secs.
+   The time threshold is set to 90 seconds.  In honesty, this time_threshold could be
+   set significantly higher to reduce unneccessary network chatter. */
+collection_group {
+  collect_every = 20
+  time_threshold = 90
+  /* CPU status */
+  metric {
+    name = "cpu_user"
+    value_threshold = "1.0"
+  }
+  metric {
+    name = "cpu_system"
+    value_threshold = "1.0"
+  }
+  metric {
+    name = "cpu_idle"
+    value_threshold = "5.0"
+  }
+  metric {
+    name = "cpu_nice"
+    value_threshold = "1.0"
+  }
+  metric {
+    name = "cpu_aidle"
+    value_threshold = "5.0"
+  }
+  metric {
+    name = "cpu_wio"
+    value_threshold = "1.0"
+  }
+  /* The next two metrics are optional if you want more detail...
+     ... since they are accounted for in cpu_system.
+  metric {
+    name = "cpu_intr"
+    value_threshold = "1.0"
+  }
+  metric {
+    name = "cpu_sintr"
+    value_threshold = "1.0"
+  }
+  */
 }
 
-/* Different than 2.5.x default since the old config made no sense */ 
-collection_group { 
-  collect_every = 1800 
-  time_threshold = 3600 
-  metric { 
-    name = "disk_total" 
-    value_threshold = 1.0 
-  } 
+collection_group {
+  collect_every = 20
+  time_threshold = 90
+  /* Load Averages */
+  metric {
+    name = "load_one"
+    value_threshold = "1.0"
+  }
+  metric {
+    name = "load_five"
+    value_threshold = "1.0"
+  }
+  metric {
+    name = "load_fifteen"
+    value_threshold = "1.0"
+  }
 }
 
-collection_group { 
-  collect_every = 40 
-  time_threshold = 180 
-  metric { 
-    name = "disk_free" 
-    value_threshold = 1.0 
-  } 
-  metric { 
-    name = "part_max_used" 
-    value_threshold = 1.0 
-  } 
+/* This group collects the number of running and total processes */
+collection_group {
+  collect_every = 80
+  time_threshold = 950
+  metric {
+    name = "proc_run"
+    value_threshold = "1.0"
+  }
+  metric {
+    name = "proc_total"
+    value_threshold = "1.0"
+  }
+}
+
+/* This collection group grabs the volatile memory metrics every 40 secs and
+   sends them at least every 180 secs.  This time_threshold can be increased
+   significantly to reduce unneeded network traffic. */
+collection_group {
+  collect_every = 40
+  time_threshold = 180
+  metric {
+    name = "mem_free"
+    value_threshold = "1024.0"
+  }
+  metric {
+    name = "mem_shared"
+    value_threshold = "1024.0"
+  }
+  metric {
+    name = "mem_buffers"
+    value_threshold = "1024.0"
+  }
+  metric {
+    name = "mem_cached"
+    value_threshold = "1024.0"
+  }
+  metric {
+    name = "swap_free"
+    value_threshold = "1024.0"
+  }
+}
+
+collection_group {
+  collect_every = 40
+  time_threshold = 300
+  metric {
+    name = "bytes_out"
+    value_threshold = 4096
+  }
+  metric {
+    name = "bytes_in"
+    value_threshold = 4096
+  }
+  metric {
+    name = "pkts_in"
+    value_threshold = 256
+  }
+  metric {
+    name = "pkts_out"
+    value_threshold = 256
+  }
+}
+
+/* Different than 2.5.x default since the old config made no sense */
+collection_group {
+  collect_every = 1800
+  time_threshold = 3600
+  metric {
+    name = "disk_total"
+    value_threshold = 1.0
+  }
+}
+
+collection_group {
+  collect_every = 40
+  time_threshold = 180
+  metric {
+    name = "disk_free"
+    value_threshold = 1.0
+  }
+  metric {
+    name = "part_max_used"
+    value_threshold = 1.0
+  }
 }
 

--- a/templates/gmond.conf.el6.erb
+++ b/templates/gmond.conf.el6.erb
@@ -66,7 +66,7 @@ udp_recv_channel {
   bind       = <%= channel['bind'] %>
   <%- end -%>
   <%- if channel['family'] then -%>
-  family     = <%= channel['family'] %> 
+  family     = <%= channel['family'] %>
   <%- end -%>
 }
 
@@ -81,7 +81,7 @@ tcp_accept_channel {
   port       = <%= channel['port'] %>
   <%- end -%>
   <%- if channel['family'] then -%>
-  family     = <%= channel['family'] %> 
+  family     = <%= channel['family'] %>
   <%- end -%>
 }
 


### PR DESCRIPTION
A number of files contained trailing whitespace, this has been removed
with the following perl one-liner.

perl -pi -e 's/ +$//' *

Not having whitespace prevents confusing diff outputs such as the
following.

https://github.com/jhoblitt/puppet-ganglia/pull/3#discussion-diff-7579522

The diff changes on the PR may seem a bit crazy with blocks seemingly removed and re-added but if you view with the following URL or do `git diff --ignore-space-at-eol` you'll see it's just space removal.

https://github.com/jhoblitt/puppet-ganglia/pull/20/files?w=1
