### PR TITLE
Fix scope problem for gmetad config

### DIFF
--- a/manifests/gmetad.pp
+++ b/manifests/gmetad.pp
@@ -49,10 +49,19 @@ class ganglia::gmetad(
   $clusters = [ { 'name' => 'my cluster', 'address' => 'localhost' } ],
   $gridname = undef,
   $rras = $ganglia::params::rras,
+  $gmetad_package_name = $ganglia::params::gmetad_package_name,
+  $gmetad_service_name = $ganglia::params::gmetad_service_name,
+  $gmetad_service_config = $ganglia::params::gmetad_service_config,
+  $gmetad_user = $ganglia::params::gmetad_user,
+  $gmetad_case_sensitive_hostnames = $ganglia::params::gmetad_case_sensitive_hostnames
 ) inherits ganglia::params {
   ganglia_validate_clusters($clusters)
   validate_string($gridname)
   ganglia_validate_rras($rras)
+  validate_string($gmetad_package_name)
+  validate_string($gmetad_service_name)
+  validate_string($gmetad_service_config)
+  validate_string($gmetad_user)
 
   anchor{ 'ganglia::gmetad::begin': } ->
   class{ 'ganglia::gmetad::install': } ->

--- a/templates/conf.php.el6.erb
+++ b/templates/conf.php.el6.erb
@@ -41,8 +41,8 @@ $graphdir='./graph.d';
 # Although, it would be strange to alter the IP since the Round-Robin
 # databases need to be local to be read.
 #
-$ganglia_ip = "<%= @ganglia_ip %>";
-$ganglia_port = <%= @ganglia_port %>;
+$ganglia_ip = "<%= scope.lookupvar('::ganglia::web::ganglia_ip') %>";
+$ganglia_port = <%= scope.lookupvar('::ganglia::web::ganglia_port') %>;
 
 #
 # The maximum number of dynamic graphs to display.  If you set this

--- a/templates/gmetad.conf.erb
+++ b/templates/gmetad.conf.erb
@@ -41,7 +41,7 @@
 # data_source "my grid" 50 1.3.4.7:8655 grid.org:8651 grid-backup.org:8651
 # data_source "another source" 1.3.4.7:8655 1.3.4.8
 
-<% @clusters.each do |data_source| -%>
+<% scope.lookupvar('::ganglia::gmetad::clusters').each do |data_source| -%>
 data_source "<%= data_source['name'] -%>"<% if data_source['polling_interval'] then -%>
  <%= data_source['polling_interval'] -%>
 <%- end -%>
@@ -64,11 +64,11 @@ data_source "<%= data_source['name'] -%>"<% if data_source['polling_interval'] t
 # New Default RRA
 # Keep 5856 data points at 15 second resolution assuming 15 second (default) polling. That's 1 day
 # Two weeks of data points at 1 minute resolution (average)
-<% unless @rras.nil? -%>
-RRAs <% @rras.each do |rra| -%>"RRA:<%= rra['cf'] -%>:<%= rra['xff'] -%>:<%= rra['steps'] -%>:<%= rra['rows'] -%>" <% end -%>
+<% unless scope.lookupvar('::ganglia::gmetad::rras').nil? -%>
+RRAs <% scope.lookupvar('::ganglia::gmetad::rras').each do |rra| -%>"RRA:<%= rra['cf'] -%>:<%= rra['xff'] -%>:<%= rra['steps'] -%>:<%= rra['rows'] -%>" <% end -%>
 <% else -%>
 #RRAs "RRA:AVERAGE:0.5:1:5856" "RRA:AVERAGE:0.5:4:20160" "RRA:AVERAGE:0.5:40:52704"
-<% end -%>
+<% end %>
 #
 #-------------------------------------------------------------------------------
 # Scalability mode. If on, we summarize over downstream grids, and respect
@@ -83,8 +83,8 @@ RRAs <% @rras.each do |rra| -%>"RRA:<%= rra['cf'] -%>:<%= rra['xff'] -%>:<%= rra
 # The name of this Grid. All the data sources above will be wrapped in a GRID
 # tag with this name.
 # default: unspecified
-<% unless @gridname.nil? -%>
-gridname "<%= @gridname %>"
+<% unless scope.lookupvar('::ganglia::gmetad::gridname').nil? -%>
+gridname "<%= scope.lookupvar('::ganglia::gmetad::gridname') %>"
 <% else -%>
 # gridname "MyGrid"
 <% end -%>
@@ -117,7 +117,7 @@ gridname "<%= @gridname %>"
 #-------------------------------------------------------------------------------
 # User gmetad will setuid to (defaults to "nobody")
 # default: "nobody"
-setuid_username "<%= @gmetad_user %>"
+setuid_username "<%= scope.lookupvar('::ganglia::gmetad::gmetad_user') %>"
 #
 #-------------------------------------------------------------------------------
 # Umask to apply to created rrd files and grid directory structure
@@ -163,7 +163,7 @@ setuid_username "<%= @gmetad_user %>"
 # From version 3.2, backwards compatibility will be disabled by default.
 # default: 1 (for gmetad < 3.2)
 # default: 0 (for gmetad >= 3.2)
-case_sensitive_hostnames <%= @gmetad_case_sensitive_hostnames %>
+case_sensitive_hostnames <%= scope.lookupvar('::ganglia::gmetad::gmetad_case_sensitive_hostnames') %>
 #-------------------------------------------------------------------------------
 # It is now possible to export all the metrics collected by gmetad directly to
 # graphite by setting the following attributes.

--- a/templates/gmond.conf.debian.erb
+++ b/templates/gmond.conf.debian.erb
@@ -18,21 +18,21 @@ globals {
  * of a <CLUSTER> tag.  If you do not specify a cluster tag, then all <HOSTS> will
  * NOT be wrapped inside of a <CLUSTER> tag. */
 cluster {
-  name = "<%= @cluster_name %>"
-  owner = "<%= @cluster_owner %>"
-  latlong = "<%= @cluster_latlong %>"
-  url = "<%= @cluster_url %>"
+  name = "<%= scope.lookupvar('::ganglia::gmond::cluster_name') %>"
+  owner = "<%= scope.lookupvar('::ganglia::gmond::cluster_owner') %>"
+  latlong = "<%= scope.lookupvar('::ganglia::gmond::cluster_latlong') %>"
+  url = "<%= scope.lookupvar('::ganglia::gmond::cluster_url') %>"
 }
 
 /* The host section describes attributes of the host, like the location */
 host {
-  location = "<%= @host_location %>"
+  location = "<%= scope.lookupvar('::ganglia::gmond::host_location') %>"
 }
 
 /* Feel free to specify as many udp_send_channels as you like.  Gmond
    used to only support having a single channel */
-<% unless @udp_send_channel.nil? -%>
-<% @udp_send_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::udp_send_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::udp_send_channel').each do |channel| -%>
 udp_send_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
@@ -51,8 +51,8 @@ udp_send_channel {
 <% end -%>
 <% end -%>
 /* You can specify as many udp_recv_channels as you like as well. */
-<% unless @udp_recv_channel.nil? -%>
-<% @udp_recv_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::udp_recv_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::udp_recv_channel').each do |channel| -%>
 udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
@@ -72,8 +72,8 @@ udp_recv_channel {
 <% end -%>
 /* You can specify as many tcp_accept_channels as you like to share
    an xml description of the state of the cluster */
-<% unless @tcp_accept_channel.nil? -%>
-<% @tcp_accept_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::tcp_accept_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::tcp_accept_channel').each do |channel| -%>
 tcp_accept_channel {
   <%- if channel['port'] then -%>
   port       = <%= channel['port'] %>

--- a/templates/gmond.conf.el5.erb
+++ b/templates/gmond.conf.el5.erb
@@ -17,21 +17,21 @@ globals {
  * of a <CLUSTER> tag.  If you do not specify a cluster tag, then all <HOSTS> will
  * NOT be wrapped inside of a <CLUSTER> tag. */
 cluster {
-  name = "<%= @cluster_name %>"
-  owner = "<%= @cluster_owner %>"
-  latlong = "<%= @cluster_latlong %>"
-  url = "<%= @cluster_url %>"
+  name = "<%= scope.lookupvar('::ganglia::gmond::cluster_name') %>"
+  owner = "<%= scope.lookupvar('::ganglia::gmond::cluster_owner') %>"
+  latlong = "<%= scope.lookupvar('::ganglia::gmond::cluster_latlong') %>"
+  url = "<%= scope.lookupvar('::ganglia::gmond::cluster_url') %>"
 }
 
 /* The host section describes attributes of the host, like the location */
 host {
-  location = "<%= @host_location %>"
+  location = "<%= scope.lookupvar('::ganglia::gmond::host_location') %>"
 }
 
 /* Feel free to specify as many udp_send_channels as you like.  Gmond
    used to only support having a single channel */
-<% unless @udp_send_channel.nil? -%>
-<% @udp_send_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::udp_send_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::udp_send_channel').each do |channel| -%>
 udp_send_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
@@ -50,8 +50,8 @@ udp_send_channel {
 <% end -%>
 <% end -%>
 /* You can specify as many udp_recv_channels as you like as well. */
-<% unless @udp_recv_channel.nil? -%>
-<% @udp_recv_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::udp_recv_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::udp_recv_channel').each do |channel| -%>
 udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
@@ -71,8 +71,8 @@ udp_recv_channel {
 <% end -%>
 /* You can specify as many tcp_accept_channels as you like to share
    an xml description of the state of the cluster */
-<% unless @tcp_accept_channel.nil? -%>
-<% @tcp_accept_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::tcp_accept_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::tcp_accept_channel').each do |channel| -%>
 tcp_accept_channel {
   <%- if channel['port'] then -%>
   port       = <%= channel['port'] %>

--- a/templates/gmond.conf.el6.erb
+++ b/templates/gmond.conf.el6.erb
@@ -20,21 +20,21 @@ globals {
  * tag that will wrap all hosts collected by this instance.
  */
 cluster {
-  name = "<%= @cluster_name %>"
-  owner = "<%= @cluster_owner %>"
-  latlong = "<%= @cluster_latlong %>"
-  url = "<%= @cluster_url %>"
+  name = "<%= scope.lookupvar('::ganglia::gmond::cluster_name') %>"
+  owner = "<%= scope.lookupvar('::ganglia::gmond::cluster_owner') %>"
+  latlong = "<%= scope.lookupvar('::ganglia::gmond::cluster_latlong') %>"
+  url = "<%= scope.lookupvar('::ganglia::gmond::cluster_url') %>"
 }
 
 /* The host section describes attributes of the host, like the location */
 host {
-  location = "<%= @host_location %>"
+  location = "<%= scope.lookupvar('::ganglia::gmond::host_location') %>"
 }
 
 /* Feel free to specify as many udp_send_channels as you like.  Gmond
    used to only support having a single channel */
-<% unless @udp_send_channel.nil? -%>
-<% @udp_send_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::udp_send_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::udp_send_channel').each do |channel| -%>
 udp_send_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
@@ -53,8 +53,8 @@ udp_send_channel {
 <% end -%>
 <% end -%>
 /* You can specify as many udp_recv_channels as you like as well. */
-<% unless @udp_recv_channel.nil? -%>
-<% @udp_recv_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::udp_recv_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::udp_recv_channel').each do |channel| -%>
 udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
@@ -74,8 +74,8 @@ udp_recv_channel {
 <% end -%>
 /* You can specify as many tcp_accept_channels as you like to share
    an xml description of the state of the cluster */
-<% unless @tcp_accept_channel.nil? -%>
-<% @tcp_accept_channel.each do |channel| -%>
+<% unless scope.lookupvar('::ganglia::gmond::tcp_accept_channel').nil? -%>
+<% scope.lookupvar('::ganglia::gmond::tcp_accept_channel').each do |channel| -%>
 tcp_accept_channel {
   <%- if channel['port'] then -%>
   port       = <%= channel['port'] %>


### PR DESCRIPTION
With future parser there is a scope problem in the gmetad.conf.erb. Because the variable "clusters" is defined in ganglia::gmetad and the template is in ganglia::gmetad::config it is not in the same scope. By inheriting ganglia::gmetad this fixes the problem.
