### PR TITLE
Change ganglia_port default to string

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -37,7 +37,9 @@ class ganglia::web(
   $ganglia_port = 8652,
 ) inherits ganglia::params {
   validate_string($ganglia_ip)
-  validate_string($ganglia_port)
+  if !(is_string($ganglia_port) or is_integer($ganglia_port)) {
+    fail('$ganglia_port is not a string or integer.')
+  }
 
   anchor{ 'ganglia::web::begin': } ->
   class{ 'ganglia::web::install': } ->


### PR DESCRIPTION
I looked at trying to validate ganglia_port as an integer for future parser, but it all seemed a bit hacky. I've changed the default to a string, this way it will work with both parsers. If people are using the current parser then passing in a bareword port number will still work.
