### PR TITLE
Fix problem with undef override_hostname

### DIFF
--- a/spec/classes/gmond_spec.rb
+++ b/spec/classes/gmond_spec.rb
@@ -27,7 +27,8 @@ describe 'ganglia::gmond' do
         with_content(/^  owner = "unspecified"$/).
         with_content(/^  latlong = "unspecified"$/).
         with_content(/^  url = "unspecified"$/).
-        with_content(/^  location = "unspecified"$/)
+        with_content(/^  location = "unspecified"$/).
+        without_content(/^  override_hostname =/)
     end
   end # default params
 

--- a/templates/gmond.conf.debian.erb
+++ b/templates/gmond.conf.debian.erb
@@ -12,9 +12,9 @@ globals {
   cleanup_threshold = 300 /*secs */
   gexec = no
   send_metadata_interval = <%= scope.lookupvar('::ganglia::gmond::globals_send_metadata_interval') %> /*secs */
-  <% unless scope.lookupvar('::ganglia::gmond::globals_override_hostname').nil? -%>
+  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') != :undef -%>
   override_hostname = <%= scope.lookupvar('::ganglia::gmond::globals_override_hostname') %>
-  <% end -%>
+  <%- end -%>
 }
 
 /* If a cluster attribute is specified, then all gmond hosts are wrapped inside

--- a/templates/gmond.conf.el5.erb
+++ b/templates/gmond.conf.el5.erb
@@ -11,9 +11,9 @@ globals {
   host_dmax = <%= scope.lookupvar('::ganglia::gmond::globals_host_dmax') %> /*secs */
   cleanup_threshold = 300 /*secs */
   gexec = no
-  <% unless scope.lookupvar('::ganglia::gmond::globals_override_hostname').nil? -%>
+  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') != :undef -%>
   override_hostname = <%= scope.lookupvar('::ganglia::gmond::globals_override_hostname') %>
-  <% end -%>
+  <%- end -%>
 }
 
 /* If a cluster attribute is specified, then all gmond hosts are wrapped inside

--- a/templates/gmond.conf.el6.erb
+++ b/templates/gmond.conf.el6.erb
@@ -13,9 +13,9 @@ globals {
   cleanup_threshold = 300 /*secs */
   gexec = no
   send_metadata_interval = <%= scope.lookupvar('::ganglia::gmond::globals_send_metadata_interval') %> /*secs */
-  <% unless scope.lookupvar('::ganglia::gmond::globals_override_hostname').nil? -%>
+  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') != :undef -%>
   override_hostname = <%= scope.lookupvar('::ganglia::gmond::globals_override_hostname') %>
-  <% end -%>
+  <%- end -%>
 }
 
 /*


### PR DESCRIPTION
If override_hostname is not defined it uses the default of undef, but the logic in the template doesn't work as expected. I've added a failing rspec test first, which I will fix in another commit.