### PR TITLE
::lsbmajdistrelease is a string now

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,7 +107,7 @@ class ganglia::params {
       $gmetad_case_sensitive_hostnames = 1
 
       # ubuntu 12.10 and below didn't have a status command in the init script
-      if ! ($::operatingsystem == 'Ubuntu' and $::lsbmajdistrelease > 12) {
+      if ! ($::operatingsystem == 'Ubuntu' and $::lsbmajdistrelease > '12') {
         $gmond_status_command  = 'pgrep -u ganglia -f /usr/sbin/gmond'
         $gmetad_status_command = 'pgrep -u nobody -f /usr/sbin/gmetad'
       }


### PR DESCRIPTION
Had trouble today with puppet 3.7.4-1puppetlabs1 and `::lsbmajdistrelease`.  Not sure if it's now a string or puppet decided to care.  I *am* using the future parser.