### PR TITLE
Fix undef predicates

### DIFF
--- a/templates/gmond.conf.debian.erb
+++ b/templates/gmond.conf.debian.erb
@@ -12,7 +12,7 @@ globals {
   cleanup_threshold = 300 /*secs */
   gexec = no
   send_metadata_interval = <%= scope.lookupvar('::ganglia::gmond::globals_send_metadata_interval') %> /*secs */
-  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') != :undef -%>
+  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') -%>
   override_hostname = <%= scope.lookupvar('::ganglia::gmond::globals_override_hostname') %>
   <%- end -%>
 }

--- a/templates/gmond.conf.el5.erb
+++ b/templates/gmond.conf.el5.erb
@@ -11,7 +11,7 @@ globals {
   host_dmax = <%= scope.lookupvar('::ganglia::gmond::globals_host_dmax') %> /*secs */
   cleanup_threshold = 300 /*secs */
   gexec = no
-  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') != :undef -%>
+  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') -%>
   override_hostname = <%= scope.lookupvar('::ganglia::gmond::globals_override_hostname') %>
   <%- end -%>
 }

--- a/templates/gmond.conf.el6.erb
+++ b/templates/gmond.conf.el6.erb
@@ -13,7 +13,7 @@ globals {
   cleanup_threshold = 300 /*secs */
   gexec = no
   send_metadata_interval = <%= scope.lookupvar('::ganglia::gmond::globals_send_metadata_interval') %> /*secs */
-  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') != :undef -%>
+  <%- if scope.lookupvar('::ganglia::gmond::globals_override_hostname') -%>
   override_hostname = <%= scope.lookupvar('::ganglia::gmond::globals_override_hostname') %>
   <%- end -%>
 }


### PR DESCRIPTION
Found these didn't work.  Not sure if it was another artifact of puppet version change, or if most people just supply `override_hostname`.