### PR TITLE
gmetad.conf - adding support for managing 'all_trusted' and 'trusted_hos...

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2012-2014 Joshua Hoblitt <jhoblitt@cpan.org>
+Copyright (C) 2012-2015 Joshua Hoblitt <jhoblitt@cpan.org>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -83,21 +83,21 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
 ```
 
  * `globals_deaf`
- 
+
   `String` defaults to: `no`
 
  * `globals_host_dmax`
- 
+
   `String` defaults to: `0`
 
  * `globals_send_metadata_interval`
- 
+
   `String` defaults to: `300`
-  
+
  * `globals_override_hostname`
- 
+
   `String` defaults to: undef
-  
+
  * `cluster_name`
 
     `String` defaults to: `unspecified`
@@ -145,7 +145,7 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
         address  => ['test1.example.org', 'test2.example.org'],
       },
     ]
-    
+
     $rras = [
       {
         cf      => 'AVERAGE',
@@ -167,12 +167,20 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
       },
     ]
 
-    class{ 'ganglia::gmetad':
-      clusters => $clusters,
-      gridname => 'my grid',
-      rras     => $rras,
+
+      clusters      => $clusters,
+      gridname      => 'my grid',
+      rras          => $rras,
+      all_trusted   => false,
+      trusted_hosts => []
     }
 ```
+
+ * `all_trusted`
+
+    `Boolean` defaults to: false
+
+    * If set to true, we will allow all hosts that can query ganglia data via the xml query port.  Corresponds to the 'all\_trusted' field in gmetad.conf.
 
  * `clusters`
 
@@ -183,11 +191,11 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
  * `gridname`
 
     `String` defaults to: `undef`
-    
+
  * `rras`
- 
+
     `Array of Hash` defaults to:
-    
+
     ```
       [
         {
@@ -210,11 +218,17 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
         },
       ]
     ```
-      
+
     * consolidation function (cf) can be AVERAGE | MIN | MAX | LAST
     * xfiles factor (xff) defines what part of a consolidation interval may be made up from *UNKNOWN* data while the consolidated value is still regarded as known. It is given as the ratio of allowed *UNKNOWN* PDPs to the number of PDPs in the interval. Thus, it ranges from 0 to 1 (exclusive).
     * steps defines how many of these primary data points are used to build a consolidated data point which then goes into the archive.
     * rows defines how many generations of data values are kept in an RRA. Obviously, this has to be greater than zero.
+
+ * `trusted_hosts`
+
+    `Array of Strings` defaults to empty array
+
+    * Each string matches a hostname that is allowed to query ganglia data via the xml query port.  Corresponds to the 'trusted\_hosts' field in gmetad.conf.
 
 ### ganglia::web
 

--- a/manifests/gmetad.pp
+++ b/manifests/gmetad.pp
@@ -6,6 +6,11 @@
 #
 # All parameteres are optional.
 #
+# [*all_trusted*]
+#   boolean, default false; if set to true, we will allow all hosts that 
+#   can query ganglia data via the xml query port.  Corresponds to the 
+#   'all_trusted' field in gmetad.conf.
+#
 # [*clusters*]
 #   array of hashes.  Valid keys are:
 #
@@ -19,6 +24,10 @@
 # [*gridname*]
 #   string - defaults to '', which means no gridname at all
 #
+# [*trusted_hosts*]
+#   array of strings, each of which matches a hostname that is allowed to
+#   query ganglia data via the xml query port.  Corresponds to the
+#   'trusted_hosts' field in gmetad.conf.
 #
 # === Examples
 #
@@ -46,9 +55,11 @@
 #
 
 class ganglia::gmetad(
+  $all_trusted = false,
   $clusters = [ { 'name' => 'my cluster', 'address' => 'localhost' } ],
   $gridname = undef,
   $rras = $ganglia::params::rras,
+  $trusted_hosts = [],
   $gmetad_package_name = $ganglia::params::gmetad_package_name,
   $gmetad_service_name = $ganglia::params::gmetad_service_name,
   $gmetad_service_config = $ganglia::params::gmetad_service_config,
@@ -62,6 +73,8 @@ class ganglia::gmetad(
   validate_string($gmetad_service_name)
   validate_string($gmetad_service_config)
   validate_string($gmetad_user)
+  validate_array($trusted_hosts)
+  validate_bool($all_trusted)
 
   anchor{ 'ganglia::gmetad::begin': } ->
   class{ 'ganglia::gmetad::install': } ->

--- a/spec/classes/gmetad_spec.rb
+++ b/spec/classes/gmetad_spec.rb
@@ -28,6 +28,41 @@ describe 'ganglia::gmetad' do
     end
   end # default params
 
+  context 'all_trusted' do
+    context 'default' do
+      it 'should disable all_trusted' do
+        should contain_file('/etc/ganglia/gmetad.conf').
+          with_content(/^all_trusted off$/)
+      end # should disable all_trusted
+    end # default
+
+    context 'all_trusted true' do
+      let(:params) {{ :all_trusted => true }}
+      it 'should enable all_trusted' do
+        should contain_file('/etc/ganglia/gmetad.conf').
+          with_content(/^all_trusted on$/)
+      end
+    end # all_trusted true
+  end # all_trusted
+
+  context 'trusted_hosts' do
+    context 'default' do
+      it 'should have an empty trusted_hosts' do
+        should contain_file('/etc/ganglia/gmetad.conf').
+          with_content(/^# trusted_hosts.*$/).
+          without_content(/^trusted_hosts.*$/)
+      end
+    end # default
+
+    context 'trusted_hosts list' do
+      let(:params) {{ :trusted_hosts => [ '1', '2' ] }}
+      it 'should enable trusted hosts' do
+        should contain_file('/etc/ganglia/gmetad.conf').
+          with_content(/^trusted_hosts 1 2$/)
+      end 
+    end # trusted_hosts list
+  end # trusted_hosts
+
   context 'clusters =>' do
     context '<good example>' do
       clusters = [

--- a/templates/gmetad.conf.erb
+++ b/templates/gmetad.conf.erb
@@ -101,13 +101,22 @@ gridname "<%= scope.lookupvar('::ganglia::gmetad::gridname') %>"
 # List of machines this gmetad will share XML with. Localhost
 # is always trusted.
 # default: There is no default value
+<% if !scope.lookupvar('::ganglia::gmetad::trusted_hosts').nil? &&
+      !scope.lookupvar('::ganglia::gmetad::trusted_hosts').empty? -%>
+trusted_hosts <%= scope.lookupvar('::ganglia::gmetad::trusted_hosts').join(' ') %>
+<% else -%>
 # trusted_hosts 127.0.0.1 169.229.50.165 my.gmetad.org
+<% end %>
 #
 #-------------------------------------------------------------------------------
 # If you want any host which connects to the gmetad XML to receive
 # data, then set this value to "on"
 # default: off
-# all_trusted on
+<%- if scope.lookupvar('::ganglia::gmetad::all_trusted') -%>
+all_trusted on
+<% else -%>
+all_trusted off
+<%- end -%>
 #
 #-------------------------------------------------------------------------------
 # If you don't want gmetad to setuid then set this to off


### PR DESCRIPTION
...ts'

Adds two optional parameters to gmetad.pp - 'all_trusted' (a boolean,
default false), and 'trusted_hosts' (array of strings, default empty).
These can be used to populate the corresponding fields in gmetad.conf.

Includes a spec file check for these parameters as well, though I haven't
tested that adequately yet.