### PR TITLE
Fix line breaks if not using arrays for ds.

### DIFF
--- a/templates/gmetad.conf.erb
+++ b/templates/gmetad.conf.erb
@@ -50,7 +50,7 @@ data_source "<%= data_source['name'] -%>"<% if data_source['polling_interval'] t
  <%= address -%>
 <%- end %>
 <%- else -%>
- <%= data_source['address'] -%>
+ <%= data_source['address'] %>
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
Fix missing line break if one does provide several hosts as string
instead of an array. Previously if using the template without a host
array the data sources got lined up on a single line.