### PR TITLE
Added option mcast_if for multicast configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This class manages the configurtion of the Ganglia `gmond` daemon.
 
     # multicast
     $udp_recv_channel = [
-      { mcast_join => '239.2.11.71', port => 8649, ttl => 1 }
+      { mcast_join => '239.2.11.71', mcast_if => 'eth0', port => 8649, ttl => 1 }
     ]
     $udp_send_channel = [
       { mcast_join => '239.2.11.71', port => 8649, bind => '239.2.11.71' }

--- a/manifests/gmond.pp
+++ b/manifests/gmond.pp
@@ -35,6 +35,7 @@
 #
 #   -bind_hostname
 #   -mcast_join
+#   -mcast_if
 #   -host
 #   -port
 #   -ttl
@@ -47,6 +48,7 @@
 #
 #   -channel
 #   -mcast_join
+#   -mcast_if
 #   -port
 #   -bind
 #   -family

--- a/spec/classes/gmond_spec.rb
+++ b/spec/classes/gmond_spec.rb
@@ -28,7 +28,8 @@ describe 'ganglia::gmond' do
         with_content(/^  latlong = "unspecified"$/).
         with_content(/^  url = "unspecified"$/).
         with_content(/^  location = "unspecified"$/).
-        without_content(/^  override_hostname =/)
+        without_content(/^  override_hostname =/).
+        without_content(/^  mcast_if/)
     end
   end # default params
 
@@ -57,8 +58,41 @@ describe 'ganglia::gmond' do
 
     let(:params) { params }
     it do
-      should contain_class('ganglia::gmond') 
-      should contain_file('/etc/ganglia/gmond.conf') 
+      should contain_class('ganglia::gmond')
+      should contain_file('/etc/ganglia/gmond.conf')
+    end
+  end
+
+  context 'with multicast channels' do
+    udp_recv_channel = [
+      {'port' => 8649, 'mcast_join' => '239.2.11.72', 'mcast_if' => 'eth0', 'bind' => '239.2.11.72'},
+    ]
+    udp_send_channel = [
+      {'port' => 8649, 'mcast_join' => '239.2.11.72', 'mcast_if' => 'eth0', 'ttl' => '1', 'bind_hostname' => 'yes'},
+    ]
+    tcp_accept_channel = [
+      {'port' => 8649},
+    ]
+    params = {
+      'cluster_name'        => "example grid",
+      'cluster_owner'       => "ACME, Inc.",
+      'cluster_latlong'     => "N32.2332147 W110.9481163",
+      'cluster_url'         => "www.example.org",
+      'host_location'       => "Example Computer Room",
+      'udp_recv_channel'    => udp_recv_channel,
+      'udp_send_channel'    => udp_send_channel,
+      'tcp_accept_channel'  => tcp_accept_channel,
+    }
+
+    let(:params) { params }
+    it do
+      should contain_class('ganglia::gmond')
+      should contain_file('/etc/ganglia/gmond.conf').
+        with_content(/^\s*bind_hostname\s+=\s+yes/).
+        with_content(/^\s*mcast_join\s+=\s+239\.2\.11\.72/).
+        with_content(/^\s*mcast_if\s+=\s+eth0/).
+        with_content(/^\s*port\s+=\s+8649/).
+        with_content(/^\s*ttl\s+=\s+1/)
     end
   end
 end

--- a/templates/gmond.conf.debian.erb
+++ b/templates/gmond.conf.debian.erb
@@ -43,6 +43,9 @@ udp_send_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
   <%- end -%>
+  <%- if channel['mcast_if'] then -%>
+  mcast_if   = <%= channel['mcast_if'] %>
+  <%- end -%>
   <%- if channel['host'] then -%>
   host       = <%= channel['host'] %>
   <%- end -%>
@@ -62,6 +65,9 @@ udp_send_channel {
 udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
+  <%- end -%>
+  <%- if channel['mcast_if'] then -%>
+  mcast_if   = <%= channel['mcast_if'] %>
   <%- end -%>
   <%- if channel['port'] then -%>
   port       = <%= channel['port'] %>

--- a/templates/gmond.conf.el5.erb
+++ b/templates/gmond.conf.el5.erb
@@ -42,6 +42,9 @@ udp_send_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
   <%- end -%>
+  <%- if channel['mcast_if'] then -%>
+  mcast_if   = <%= channel['mcast_if'] %>
+  <%- end -%>
   <%- if channel['host'] then -%>
   host       = <%= channel['host'] %>
   <%- end -%>
@@ -61,6 +64,9 @@ udp_send_channel {
 udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
+  <%- end -%>
+  <%- if channel['mcast_if'] then -%>
+  mcast_if   = <%= channel['mcast_if'] %>
   <%- end -%>
   <%- if channel['port'] then -%>
   port       = <%= channel['port'] %>

--- a/templates/gmond.conf.el6.erb
+++ b/templates/gmond.conf.el6.erb
@@ -45,6 +45,9 @@ udp_send_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
   <%- end -%>
+  <%- if channel['mcast_if'] then -%>
+  mcast_if   = <%= channel['mcast_if'] %>
+  <%- end -%>
   <%- if channel['host'] then -%>
   host       = <%= channel['host'] %>
   <%- end -%>
@@ -64,6 +67,9 @@ udp_send_channel {
 udp_recv_channel {
   <%- if channel['mcast_join'] then -%>
   mcast_join = <%= channel['mcast_join'] %>
+  <%- end -%>
+  <%- if channel['mcast_if'] then -%>
+  mcast_if   = <%= channel['mcast_if'] %>
   <%- end -%>
   <%- if channel['port'] then -%>
   port       = <%= channel['port'] %>


### PR DESCRIPTION
As previously already announced, I'd like to contribute a new option to multicast configuraton of gmond:

Often it is desirable to limit multicast traffic to certain interfaces only. gmond features the configuration option mcast_if for udp_send_channel and udp_recv_channels, which was added to gmond erb templates.

Cheers
Michael