### PR TITLE
Add gmond_package_name as a parameter for ganglia::gmond

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Usage
     { port => 8649 },
   ]
 
+  $gmond_package_name = [ 'ganglia-gmond', 'ganglia-gmond-python' ]
+
   class{ 'ganglia::gmond':
     globals_deaf                   => 'yes',
     globals_host_dmax              => '691200',
@@ -81,6 +83,7 @@ Usage
     udp_recv_channel               => $udp_recv_channel,
     udp_send_channel               => $udp_send_channel,
     tcp_accept_channel             => $tcp_accept_channel,
+    gmond_package_name             => $gmond_package_name,
   }
 ```
 
@@ -154,6 +157,7 @@ class { 'ganglia::gmond':
     { mcast_join => '239.2.11.71', port => 8649, bind => '239.2.11.71' }
   ],
   tcp_accept_channel               => [ { port => 8659 } ],
+  gmond_package_name               => $::ganglia::params::gmond_package_name,
 }
 ```
 
@@ -232,6 +236,10 @@ Supported hash keys are (all optional):
 
 * `port`
 * `family`
+
+##### `gmond_package_name`
+
+`String or Array` defaults to: `$::ganglia::params::gmond_package_name`
 
 #### ganglia::gmetad
 

--- a/manifests/gmond.pp
+++ b/manifests/gmond.pp
@@ -17,6 +17,7 @@ class ganglia::gmond (
     { mcast_join => '239.2.11.71', port => 8649, bind => '239.2.11.71' }
   ],
   $tcp_accept_channel             = [ { port => 8659 } ],
+  $gmond_package_name             = $::ganglia::params::gmond_package_name,
 ) inherits ganglia::params {
   validate_string($globals_deaf)
   validate_string($globals_host_dmax)
@@ -32,6 +33,9 @@ class ganglia::gmond (
   validate_array($udp_send_channel)
   validate_array($udp_recv_channel)
   validate_array($tcp_accept_channel)
+  if !(is_string($gmond_package_name) or is_array($gmond_package_name)) {
+    fail('$gmond_package_name is not a string or array.')
+  }
 
   if ($::ganglia::params::gmond_status_command) {
     $hasstatus = false
@@ -40,17 +44,17 @@ class ganglia::gmond (
   }
 
   if versioncmp($::puppetversion, '3.6.0') > 0 {
-    package { $::ganglia::params::gmond_package_name:
+    package { $gmond_package_name:
       ensure        => present,
       allow_virtual => false,
     }
   } else {
-    package { $::ganglia::params::gmond_package_name:
+    package { $gmond_package_name:
       ensure => present,
     }
   }
 
-  Package[$::ganglia::params::gmond_package_name] ->
+  Package[$gmond_package_name] ->
   file { $::ganglia::params::gmond_service_config:
     ensure  => present,
     owner   => 'root',

--- a/spec/classes/gmond_spec.rb
+++ b/spec/classes/gmond_spec.rb
@@ -16,6 +16,8 @@ describe 'ganglia::gmond' do
     it do
       should contain_file('/etc/ganglia/gmond.conf').
         that_notifies('Service[gmond]')
+      should contain_package('ganglia-gmond').
+        with_ensure('present')
     end
 
     it 'should have default values in gmond.conf template' do
@@ -93,6 +95,21 @@ describe 'ganglia::gmond' do
         with_content(/^\s*mcast_if\s+=\s+eth0/).
         with_content(/^\s*port\s+=\s+8649/).
         with_content(/^\s*ttl\s+=\s+1/)
+    end
+  end
+
+  context 'with gmond_package_name' do
+    gmond_package_name = [ 'ganglia-gmond', 'ganglia-gmond-python' ]
+    params = {
+      'gmond_package_name'  => gmond_package_name,
+    }
+
+    let(:params) { params }
+    it do
+      should contain_package('ganglia-gmond').
+        with_ensure('present')
+      should contain_package('ganglia-gmond-python').
+        with_ensure('present')
     end
   end
 end


### PR DESCRIPTION
Allow users to specify an array of packages for the ganglia::gmond module. This is convenient for including the ganglia-gmond-python module on RHEL systems.

See also: jhoblitt/puppet-ganglia#60