### PR TITLE
Set puppetversion in the facts for rspec tests

### DIFF
--- a/spec/classes/gmetad_spec.rb
+++ b/spec/classes/gmetad_spec.rb
@@ -137,7 +137,7 @@ describe 'ganglia::gmetad' do
   context 'RedHat' do
     %w{6 7}.each do |rel|
       context rel do
-        let(:facts) {{ :osfamily => 'RedHat', :operatingsystemmajrelease => rel }}
+        let(:facts) {{ :osfamily => 'RedHat', :operatingsystemmajrelease => rel, :puppetversion => Puppet.version }}
 
         it_behaves_like 'RedHat 6.x'
       end

--- a/spec/classes/gmond_spec.rb
+++ b/spec/classes/gmond_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'ganglia::gmond' do
-  let(:facts) {{ :osfamily => 'RedHat', :operatingsystemmajrelease => '6' }}
+  let(:facts) {{ :osfamily => 'RedHat', :operatingsystemmajrelease => '6', :puppetversion => Puppet.version }}
 
   context 'default params' do
     it 'should manage gmond.conf' do

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'ganglia::web' do
-  let(:facts) {{ :osfamily => 'RedHat', :operatingsystemmajrelease => '6' }}
+  let(:facts) {{ :osfamily => 'RedHat', :operatingsystemmajrelease => '6', :puppetversion => Puppet.version }}
 
   context 'parameters' do
     context 'with out params' do


### PR DESCRIPTION
I found some discussion of the "'versioncmp' parameter 'a' expects a String value, got Undef" error: https://tickets.puppetlabs.com/browse/PUP-5683

Passing the Puppet.version parameter along in the facts appears to resolve the error. The tests should probably also be expanded to validate the cases where puppetversion is used in the manifests.