### PR TITLE
Allow package ensure to be overridden

### DIFF
--- a/manifests/gmetad.pp
+++ b/manifests/gmetad.pp
@@ -9,6 +9,7 @@ class ganglia::gmetad(
   $rras                            = $::ganglia::params::rras,
   $trusted_hosts                   = [],
   $gmetad_package_name             = $::ganglia::params::gmetad_package_name,
+  $gmetad_package_ensure           = 'present',
   $gmetad_service_name             = $::ganglia::params::gmetad_service_name,
   $gmetad_service_config           = $::ganglia::params::gmetad_service_config,
   $gmetad_user                     = $::ganglia::params::gmetad_user,
@@ -22,6 +23,7 @@ class ganglia::gmetad(
   ganglia_validate_rras($rras)
   validate_array($trusted_hosts)
   validate_string($gmetad_package_name)
+  validate_string($gmetad_package_ensure)
   validate_string($gmetad_service_name)
   validate_string($gmetad_service_config)
   validate_string($gmetad_user)
@@ -36,12 +38,14 @@ class ganglia::gmetad(
 
   if versioncmp($::puppetversion, '3.6.0') > 0 {
     package { $gmetad_package_name:
-      ensure        => present,
+      ensure        => $gmetad_package_ensure,
       allow_virtual => false,
+      notify        => Service[$gmetad_service_name],
     }
   } else {
     package { $gmetad_package_name:
-      ensure => present,
+      ensure => $gmetad_package_ensure,
+      notify => Service[$gmetad_service_name],
     }
   }
 

--- a/manifests/gmond.pp
+++ b/manifests/gmond.pp
@@ -18,6 +18,7 @@ class ganglia::gmond (
   ],
   $tcp_accept_channel             = [ { port => 8659 } ],
   $gmond_package_name             = $::ganglia::params::gmond_package_name,
+  $gmond_package_ensure           = 'present',
   $gmond_service_name             = $::ganglia::params::gmond_service_name,
   $gmond_service_config           = $::ganglia::params::gmond_service_config,
   $gmond_status_command           = $::ganglia::params::gmond_status_command,
@@ -39,6 +40,7 @@ class ganglia::gmond (
   if !(is_string($gmond_package_name) or is_array($gmond_package_name)) {
     fail('$gmond_package_name is not a string or array.')
   }
+  validate_string($gmond_package_ensure)
   validate_string($gmond_service_name)
   validate_string($gmond_service_config)
   validate_string($gmond_status_command)
@@ -51,12 +53,14 @@ class ganglia::gmond (
 
   if versioncmp($::puppetversion, '3.6.0') > 0 {
     package { $gmond_package_name:
-      ensure        => present,
+      ensure        => $gmond_package_ensure,
       allow_virtual => false,
+      notify        => Service[$gmond_service_name],
     }
   } else {
     package { $gmond_package_name:
-      ensure => present,
+      ensure => $gmond_package_ensure,
+      notify => Service[$gmond_service_name],
     }
   }
 


### PR DESCRIPTION
Add gmond_package_ensure parameter to ganglia::gmond
Add gmetad_package_ensure parameter to ganglia::gmetad
gmond and gmetad will notify their respective service
