### PR TITLE
Allow package ensure to be overridden

### DIFF
--- a/manifests/gmetad.pp
+++ b/manifests/gmetad.pp
@@ -23,6 +23,7 @@ class ganglia::gmetad (
   Tuple $rras                          = $ganglia::params::rras,
   Array $trusted_hosts                 = [],
   String $gmetad_package_name          = $ganglia::params::gmetad_package_name,
+  String $gmetad_package_ensure        = 'present',
   String $gmetad_service_name          = $ganglia::params::gmetad_service_name,
   String $gmetad_service_config        = $ganglia::params::gmetad_service_config,
   String $gmetad_user                  = $ganglia::params::gmetad_user,
@@ -42,12 +43,14 @@ class ganglia::gmetad (
 
   if versioncmp($::puppetversion, '3.6.0') > 0 {
     package { $gmetad_package_name:
-      ensure        => present,
+      ensure        => $gmetad_package_ensure,
       allow_virtual => false,
+      notify        => Service[$gmetad_service_name],
     }
   } else {
     package { $gmetad_package_name:
-      ensure => present,
+      ensure => $gmetad_package_ensure,
+      notify => Service[$gmetad_service_name],
     }
   }
 

--- a/manifests/gmond.pp
+++ b/manifests/gmond.pp
@@ -35,6 +35,7 @@ class ganglia::gmond (
   Tuple $udp_recv_channel                           = [{ mcast_join => '239.2.11.71', port => 8649, bind => '239.2.11.71' }],
   Tuple $tcp_accept_channel                         = [{ port => 8659 }],
   Variant[String, Tuple] $gmond_package_name        = $ganglia::params::gmond_package_name,
+  String $gmond_package_ensure                      = 'present',
   String $gmond_service_name                        = $ganglia::params::gmond_service_name,
   String $gmond_service_config                      = $ganglia::params::gmond_service_config,
   String $gmond_status_command                      = $ganglia::params::gmond_status_command,
@@ -48,12 +49,14 @@ class ganglia::gmond (
 
   if versioncmp($::puppetversion, '3.6.0') > 0 {
     package { $gmond_package_name:
-      ensure        => present,
+      ensure        => $gmond_package_ensure,
       allow_virtual => false,
+      notify        => Service[$gmond_service_name],
     }
   } else {
     package { $gmond_package_name:
-      ensure => present,
+      ensure => $gmond_package_ensure,
+      notify => Service[$gmond_service_name],
     }
   }
 


### PR DESCRIPTION
Add gmond_package_ensure parameter to ganglia::gmond
Add gmetad_package_ensure parameter to ganglia::gmetad
gmond and gmetad will notify their respective service