### PR TITLE
Updates to EL8 defaults

### DIFF
--- a/manifests/gmond.pp
+++ b/manifests/gmond.pp
@@ -5,6 +5,8 @@
 # @param globals_host_dmax
 # @param globals_send_metadata_interval
 # @param globals_override_hostname
+# @param globals_user
+# @param globals_max_udp_msg_len
 # @param cluster_name
 # @param cluster_owner
 # @param cluster_latlong
@@ -27,6 +29,8 @@ class ganglia::gmond (
   String $globals_host_dmax                         = '0',
   String $globals_send_metadata_interval            = '300',
   Optional[Stdlib::Fqdn] $globals_override_hostname = undef,
+  String $globals_user                              = 'ganglia',
+  Integer $globals_max_udp_msg_len                  = 1472,
   String $cluster_name                              = 'unspecified',
   String $cluster_owner                             = 'unspecified',
   String $cluster_latlong                           = 'unspecified',

--- a/spec/classes/gmond_spec.rb
+++ b/spec/classes/gmond_spec.rb
@@ -64,14 +64,16 @@ describe 'ganglia::gmond' do
           { 'port' => 8649 },
         ]
         params = {
-          'cluster_name'        => 'example grid',
-          'cluster_owner'       => 'ACME, Inc.',
-          'cluster_latlong'     => 'N32.2332147 W110.9481163',
-          'cluster_url'         => 'www.example.org',
-          'host_location'       => 'Example Computer Room',
-          'udp_recv_channel'    => udp_recv_channel,
-          'udp_send_channel'    => udp_send_channel,
-          'tcp_accept_channel'  => tcp_accept_channel,
+          'cluster_name'            => 'example grid',
+          'cluster_owner'           => 'ACME, Inc.',
+          'cluster_latlong'         => 'N32.2332147 W110.9481163',
+          'cluster_url'             => 'www.example.org',
+          'host_location'           => 'Example Computer Room',
+          'globals_user'            => 'ganglia',
+          'globals_max_udp_msg_len' => 1472,
+          'udp_recv_channel'        => udp_recv_channel,
+          'udp_send_channel'        => udp_send_channel,
+          'tcp_accept_channel'      => tcp_accept_channel,
         }
 
         let(:params) { params }
@@ -79,6 +81,8 @@ describe 'ganglia::gmond' do
         it do
           is_expected.to contain_class('ganglia::gmond')
           is_expected.to contain_file('/etc/ganglia/gmond.conf')
+            .with_content(%r{^\s*max_udp_msg_len\s+=\s+1472})
+            .with_content(%r{^\s*user\s+=\s+ganglia})
         end
       end
 

--- a/templates/gmond.conf.debian.erb
+++ b/templates/gmond.conf.debian.erb
@@ -3,9 +3,9 @@
 globals {
   daemonize = yes
   setuid = yes
-  user = ganglia
+  user = <%= @globals_user %>
   debug_level = 0
-  max_udp_msg_len = 1472
+  max_udp_msg_len = <%= @globals_max_udp_msg_len %>
   mute = no
   deaf = <%= @globals_deaf %>
   host_dmax = <%= @globals_host_dmax %> /*secs */

--- a/templates/gmond.conf.el6.erb
+++ b/templates/gmond.conf.el6.erb
@@ -3,9 +3,13 @@
 globals {
   daemonize = yes
   setuid = yes
-  user = nobody
+  <%- if @globals_user -%>
+  user = <%= @globals_user %>
+  <%- else -%>
+  user = ganglia
+  <%- end -%>
   debug_level = 0
-  max_udp_msg_len = 1472
+  max_udp_msg_len = <%= @globals_max_udp_msg_len %>
   mute = no
   deaf = <%= @globals_deaf %>
   allow_extra_data = yes


### PR DESCRIPTION
- new param globals_user
- new param globals_max_udp_msg_len
- gmond.conf.debian.erb now makes me think EL defaults look the same
- templates/gmond.conf.el6.erb also makes me think we could settle on a single template
- default user now ganglia as class param, and in testing
- spec updates for checking the content of our new params