### PR TITLE
add support for RHEL9

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,7 @@ class ganglia::params {
         }
         default: {
           case $facts['os']['release']['major'] {
-            '7', '8': {
+            '7', '8', '9': {
               $gmond_service_config = '/etc/ganglia/gmond.conf'
               $gmetad_user          = 'ganglia'
               $gmond_service_erb    = 'ganglia/gmond.conf.el6.erb'

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,8 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
Verified on a rhel9 server. gmond client is working fine with the puppet module.